### PR TITLE
[Feat] 회원가입 기능 구현

### DIFF
--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/controller/UserController.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.smile.fridaymarket_auth.domain.user.controller;
+
+import com.smile.fridaymarket_auth.domain.user.dto.UserCreateRequest;
+import com.smile.fridaymarket_auth.domain.user.service.UserService;
+import com.smile.fridaymarket_auth.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "회원가입", description = "회원가입")
+    @RequestMapping(value = "", method = RequestMethod.POST)
+    public SuccessResponse<String> signup(@Valid @RequestBody UserCreateRequest userCreateRequest) {
+        userService.signup(userCreateRequest);
+        return SuccessResponse.successWithNoData("회원가입 성공");
+    }
+
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/dto/UserCreateRequest.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/dto/UserCreateRequest.java
@@ -1,0 +1,33 @@
+package com.smile.fridaymarket_auth.domain.user.dto;
+
+import com.smile.fridaymarket_auth.domain.user.entity.User;
+import com.smile.fridaymarket_auth.domain.user.service.validation.ValidPassword;
+import com.smile.fridaymarket_auth.domain.user.service.validation.ValidPhoneNumber;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UserCreateRequest {
+
+    @NotBlank(message = "아이디는 필수 값입니다.")
+    @Size(min = 3, max = 20, message = "아이디는 3자리 이상 20자리 이하로 설정해야 합니다.")
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수 값입니다.")
+    @ValidPassword
+    private String password;
+
+    @NotBlank(message = "전화번호는 필수 값입니다.")
+    @ValidPhoneNumber
+    private String phoneNumber;
+
+    public User createUser() {
+        return User.builder()
+                .username(username)
+                .password(password)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/entity/User.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/entity/User.java
@@ -1,0 +1,44 @@
+package com.smile.fridaymarket_auth.domain.user.entity;
+
+import com.smile.fridaymarket_auth.global.entity.Timestamped;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Table(name = "TB_USER")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "USER_ID", columnDefinition = "UUID")
+    private UUID id;
+
+    @Column(name = "USERNAME", length = 20, nullable = false, unique = true)
+    private String username;
+
+    @Column(name = "PASSWORD", nullable = false)
+    private String password;
+
+    @Column(name = "PHONE_NUMBER", length = 20, nullable = false)
+    private String phoneNumber;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "USER_ROLE", length = 20)
+    private Set<UserRole> userRole = new HashSet<>();
+
+    @Column(name = "IS_DELETED", nullable = false)
+    private Boolean isDeleted = false;
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/entity/UserRole.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/entity/UserRole.java
@@ -1,0 +1,17 @@
+package com.smile.fridaymarket_auth.domain.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserRole {
+
+    NORMAL("일반 권한"),
+    BUYER("구매자 권한"),
+    SELLER("판매자 권한"),
+    ADMIN("관리자 권한"),
+    SUPER_ADMIN("최종 관리자 권한");
+
+    private final String displayName;
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/repository/UserRepository.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.smile.fridaymarket_auth.domain.user.repository;
+
+import com.smile.fridaymarket_auth.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+
+    Optional<User> findByUsername(String username);
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserReader.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserReader.java
@@ -1,0 +1,7 @@
+package com.smile.fridaymarket_auth.domain.user.service;
+
+public interface UserReader {
+
+    void checkUsernameDuplicate(String username);
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserReaderImpl.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserReaderImpl.java
@@ -1,0 +1,30 @@
+package com.smile.fridaymarket_auth.domain.user.service;
+
+import com.smile.fridaymarket_auth.domain.user.repository.UserRepository;
+import com.smile.fridaymarket_auth.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.smile.fridaymarket_auth.global.exception.ErrorCode.ILLEGAL_USERNAME_DUPLICATION;
+
+@Component
+@RequiredArgsConstructor
+public class UserReaderImpl implements UserReader {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 아이디 중복체크
+     * @param username 아이디
+     */
+    @Override
+    public void checkUsernameDuplicate(String username) {
+
+        userRepository.findByUsername(username).ifPresent(
+                user -> {
+                    throw new CustomException(ILLEGAL_USERNAME_DUPLICATION);
+                }
+        );
+    }
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserService.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserService.java
@@ -1,0 +1,12 @@
+package com.smile.fridaymarket_auth.domain.user.service;
+
+import com.smile.fridaymarket_auth.domain.user.dto.UserCreateRequest;
+import jakarta.validation.Valid;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface UserService {
+
+    void signup(@Valid UserCreateRequest userCreateRequest);
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImpl.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,27 @@
+package com.smile.fridaymarket_auth.domain.user.service;
+
+import com.smile.fridaymarket_auth.domain.user.dto.UserCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserReader userReader;
+    private final UserStore userStore;
+
+    @Override
+    @Transactional
+    public void signup(UserCreateRequest userCreateRequest) {
+
+        // 사용자 아이디 중복 체크
+        userReader.checkUsernameDuplicate(userCreateRequest.getUsername());
+        // 사용자 객체 생성 및 저장
+        userStore.store(userCreateRequest.createUser());
+
+    }
+
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserStore.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserStore.java
@@ -1,0 +1,9 @@
+package com.smile.fridaymarket_auth.domain.user.service;
+
+import com.smile.fridaymarket_auth.domain.user.entity.User;
+
+public interface UserStore {
+
+    User store(User initUser);
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserStoreImpl.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserStoreImpl.java
@@ -1,0 +1,37 @@
+package com.smile.fridaymarket_auth.domain.user.service;
+
+import com.smile.fridaymarket_auth.domain.user.entity.User;
+import com.smile.fridaymarket_auth.domain.user.entity.UserRole;
+import com.smile.fridaymarket_auth.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class UserStoreImpl implements UserStore {
+
+    private final UserRepository userRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+
+    @Override
+    public User store(User initUser) {
+
+        User user = User.builder()
+                .username(initUser.getUsername())
+                .password(passwordEncoder.encode(initUser.getPassword()))
+                .phoneNumber(initUser.getPhoneNumber())
+                // 구매 주문 또는 판매 주문 작성 전에는 일반 권한을 기본 값으로 설정
+                .userRole(Set.of(UserRole.NORMAL))
+                // 사용자 탈퇴 여부는 false를 기본 값으로 설정
+                .isDeleted(false)
+                .build();
+
+        return userRepository.save(user);
+    }
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/validation/PasswordValidator.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/validation/PasswordValidator.java
@@ -1,0 +1,24 @@
+package com.smile.fridaymarket_auth.domain.user.service.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PasswordValidator implements ConstraintValidator<ValidPassword, String> {
+
+    private static final String PASSWORD_PATTERN = "^[a-zA-Z0-9!@#$%^&*]{10,20}$";
+
+    @Override
+    public boolean isValid(String password, ConstraintValidatorContext context) {
+        if (password == null || password.length() < 10 || password.length() > 20) {
+            return false;
+        }
+
+        int count = 0;
+        if (password.matches(".*[a-zA-Z].*")) count++;
+        if (password.matches(".*[0-9].*")) count++;
+        if (password.matches(".*[!@#$%^&*].*")) count++;
+
+        return count >= 2;
+    }
+}
+

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/validation/PhoneNumberValidator.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/validation/PhoneNumberValidator.java
@@ -1,0 +1,25 @@
+package com.smile.fridaymarket_auth.domain.user.service.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+
+public class PhoneNumberValidator implements ConstraintValidator<ValidPhoneNumber, String> {
+
+    private static final String PHONE_NUMBER_REGEX = "^010\\d{8}$|^02\\d{8}$|^0[3-9]\\d{8}$";
+    private static final Pattern PHONE_NUMBER_PATTERN = Pattern.compile(PHONE_NUMBER_REGEX);
+
+    @Override
+    public void initialize(ValidPhoneNumber constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(String phoneNumber, ConstraintValidatorContext context) {
+        if (phoneNumber == null || phoneNumber.isEmpty()) {
+            return false;
+        }
+        return PHONE_NUMBER_PATTERN.matcher(phoneNumber).matches();
+    }
+}
+
+

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/validation/ValidPassword.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/validation/ValidPassword.java
@@ -1,0 +1,21 @@
+package com.smile.fridaymarket_auth.domain.user.service.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = PasswordValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPassword {
+
+    String message() default "비밀번호는 10자 이상, 20자 이하 영문자, 숫자, 특수문자 중 2가지 이상 포함해야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/validation/ValidPhoneNumber.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/validation/ValidPhoneNumber.java
@@ -1,0 +1,17 @@
+package com.smile.fridaymarket_auth.domain.user.service.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = PhoneNumberValidator.class)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPhoneNumber {
+    String message() default "유효하지 않은 전화번호입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/config/WebSecurityConfig.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/config/WebSecurityConfig.java
@@ -1,0 +1,49 @@
+package com.smile.fridaymarket_auth.global.config;
+
+import com.smile.fridaymarket_auth.domain.auth.JwtAuthenticationFilter;
+import com.smile.fridaymarket_auth.domain.auth.token.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+
+        return new BCryptPasswordEncoder();
+    }
+
+    private final TokenProvider tokenProvider;
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http
+                .csrf((AbstractHttpConfigurer::disable))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(HttpMethod.POST, ("/api/users/**")).permitAll()
+                        .requestMatchers("/swagger-ui/**",
+                                "/swagger-ui.html").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/exception/ErrorCode.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/exception/ErrorCode.java
@@ -4,8 +4,10 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class ErrorCode {
+public enum ErrorCode {
 
+    ILLEGAL_USERNAME_DUPLICATION(HttpStatus.BAD_REQUEST,  "중복된 아이디입니다.");
+    
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/exception/handler/GlobalExceptionHandler.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/exception/handler/GlobalExceptionHandler.java
@@ -62,9 +62,10 @@ public class GlobalExceptionHandler {
 
         log.error("handleBindException : {}", ex.getMessage());
 
-
         String message = ex.getMessage();
-        String defaultMsg = message.substring(message.lastIndexOf("[") + 1, message.lastIndexOf("]")); // "[" 또는 "]" 기준으로 메시지 추출
+
+        String defaultMsg = message.substring(message.lastIndexOf("[") + 1, message.lastIndexOf("]") - 1); // "[" 또는 "]" 기준으로 메시지 추출
+        log.error("에러 메세지 : {}", defaultMsg);
 
         ErrorResponse response = ErrorResponse.create()
                 .message(defaultMsg)

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/response/ErrorResponse.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/response/ErrorResponse.java
@@ -4,15 +4,16 @@ import org.springframework.http.HttpStatus;
 
 public class ErrorResponse {
 
+    public boolean success; // 기본 값은 false
     public String message; // 예외 메세지
     public HttpStatus httpStatus; // Http 상태 값 400, 404, 500 등
 
     public ErrorResponse() {
-
+        this.success = false;
     }
 
     public ErrorResponse(HttpStatus status, String message) {
-
+        this.success = false;
         this.httpStatus = status;
         this.message = message;
     }

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/response/SuccessResponse.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/response/SuccessResponse.java
@@ -7,19 +7,19 @@ import lombok.Getter;
 @Builder
 public class SuccessResponse<T> {
 
-    private Result result;
+    private boolean success;
     private String message;
     private T data;
 
     private static <T> SuccessResponse<T> success(T data, String message) {
         return SuccessResponse.<T>builder()
-                .result(Result.SUCCESS)
+                .success(true)
                 .message(message)
                 .data(data)
                 .build();
     }
 
-    public static <T> SuccessResponse<T> success(T data) {
+    public static <T> SuccessResponse<T> successWithData(T data) {
         return success(data, "OK");
     }
 
@@ -27,7 +27,4 @@ public class SuccessResponse<T> {
         return success(null, message);
     }
 
-    public enum Result {
-        SUCCESS, FAIL
-    }
 }


### PR DESCRIPTION
## 📌 작업 내용
- 회원가입 기능 구현하였습니다.
- 각 Service별 기능 분리를 위해 UserReaderImpl, UserStoreImpl 클래스를 생성하였고 각각 UserReader, UserStore 인터페이스를 상속받아 사용하였습니다.
- 사용자의 아이디, 비밀번호, 전화번호 검증을 위해 @Valid 를 사용했고, dto단에 애노테이션을 설정하여 요구 사항 미충족 시 에러를 반환하도록 설정하였습니다.
- 비밀번호와 전화번호의 경우 각각 Validator를 생성해 dto에 애노테이션으로 적용될 수 있도록 하였습니다.

<br/>

## 🌱 반영 브랜치
- FM-2-feat/user-create -> dev
- close #3 

<br/>

## 🔥 트러블 슈팅
-  회원정보의 보안성을 고려해 사용자의 id 값을 UUID로 설정하였고, 회원가입을 진행하는 과정에서 오류가 발생하였습니다.

`java.sql.SQLSyntaxErrorException: (conn=46) Data too long for column 'user_id' at row 1`

DB의 user_id 타입과 User Entity에 columnDefinition으로 설정해 둔 값은 모두 binary(16) 타입으로 일치하였음에도 데이터가 너무 길어 등록에 실패했다는 오류 메세지 였습니다.

검색을 통해 mariaDB의 버전에 따라 UUID 타입을 지정하는 데 차이가 있다는 결과를 알게 되었습니다.
도커로 mariaDB를 사용 중이었기에, 터미널에 ```docker ps``` 와 ```docker logs ${mariaDB_container_name}``` 를 입력해 현재 사용 중인 버전을 확인하였고, 10.7 버전 이상의 경우 Binary(16)이 아닌 UUID 설정을 지원한다는 내용을 바탕으로 수정하여 해결하였습니다.

<img width="286" alt="image" src="https://github.com/user-attachments/assets/512294ac-808d-49e6-90c5-4cdea5db4abc">

<br>

<img width="665" alt="image" src="https://github.com/user-attachments/assets/82eca380-e22c-4b3f-881a-616365c87453">
