### PR TITLE
[Feat] 회원정보 조회 기능 구현

### DIFF
--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/auth/JwtAuthenticationFilter.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,34 @@
+package com.smile.fridaymarket_auth.domain.auth;
+
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        // header에서 token을 받아온다
+        String token = jwtTokenProvider.resolveToken(request);
+
+        if (!(token == null)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token, response);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/auth/JwtTokenProvider.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/auth/JwtTokenProvider.java
@@ -1,0 +1,148 @@
+package com.smile.fridaymarket_auth.domain.auth;
+
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smile.fridaymarket_auth.domain.auth.token.service.JwtTokenUtils;
+import com.smile.fridaymarket_auth.global.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${JWT_SECRET_KEY}")
+    private String JWT_SECRET;
+
+    private final Logger logger = LoggerFactory.getLogger(JwtTokenProvider.class);
+    private final UserDetailsServiceImpl userDetailsService;
+
+    private static final String TOKEN_PREFIX = "Bearer "; // JWT 토큰의 접두사
+
+    /**
+     * HTTP 요청에서 JWT AccessToken 을 추출합니다.
+     *
+     * @param request HTTP 요청 객체
+     * @return JWT 토큰 문자열 반환
+     */
+    public String resolveToken(HttpServletRequest request) {
+
+        String bearerToken = request.getHeader("Authorization");
+        log.info("token : {}", bearerToken);
+
+        // Authorization 헤더가 존재하고, "Bearer "로 시작하는 경우 토큰을 추출
+        if (bearerToken != null && bearerToken.startsWith(TOKEN_PREFIX)) {
+            return bearerToken.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+
+    /**
+     * JWT AccessToken 을 기반으로 인증 정보를 생성합니다.
+     *
+     * @param token    JWT AccessToken
+     * @param response HTTP 응답 객체
+     * @return Authentication 객체 반환
+     * @throws IOException 예외 발생 시
+     */
+    public Authentication getAuthentication(String token, HttpServletResponse response) throws IOException {
+
+        // 토큰에서 사용자 정보를 추출하여 UserDetails를 로드
+        UserDetails userDetails = userDetailsService.loadUserByUsername(decodeUsername(token, response));
+        return new UsernamePasswordAuthenticationToken(
+                userDetails, "", userDetails.getAuthorities());
+    }
+
+    /**
+     * JWT AccessToken 에서 사용자 계정명을 추출합니다.
+     *
+     * @param token    JWT AccessToken
+     * @param response HTTP 응답 객체
+     * @return 사용자 계정명 반환
+     * @throws IOException 예외 발생 시
+     */
+    public String decodeUsername(String token, HttpServletResponse response) throws IOException {
+
+        // 토큰의 유효성을 검사하고, 유효한 경우 사용자 계정명을 추출
+        DecodedJWT decodedJWT = isValidToken(token, response)
+                .orElseThrow(() -> new IllegalArgumentException("유효한 토큰이 아닙니다."));
+
+        return decodedJWT
+                .getClaim(JwtTokenUtils.CLAIM_USERNAME)
+                .asString();
+    }
+
+    /**
+     * JWT 토큰의 유효성을 검사합니다.
+     *
+     * @param token    JWT 토큰
+     * @param response HTTP 응답 객체
+     * @return 유효한 토큰을 DecodedJWT로 반환, 유효하지 않으면 Optional.empty()
+     * @throws IOException 예외 발생 시
+     */
+    public Optional<DecodedJWT> isValidToken(String token, HttpServletResponse response) throws IOException {
+
+        DecodedJWT jwt = null;
+        try {
+            // JWT 토큰 검증을 위한 JWTVerifier 생성
+            JWTVerifier verifier = JWT
+                    .require(generateAlgorithm(JWT_SECRET))
+                    .build();
+            jwt = verifier.verify(token);
+        } catch (TokenExpiredException e) {
+            // JWT 토큰 만료된 경우 에러 처리
+            logger.error(e.getMessage());
+            tokenExpired(response);
+        }
+        return Optional.ofNullable(jwt);
+    }
+
+    /**
+     * 만료된 JWT 토큰 에 대한 에러 응답을 생성합니다.
+     *
+     * @param response HTTP 응답 객체
+     * @throws IOException 예외 발생 시
+     */
+    public void tokenExpired(HttpServletResponse response) throws IOException {
+
+        response.setStatus(SC_UNAUTHORIZED);
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다.");
+        new ObjectMapper().writeValue(response.getWriter(), errorResponse);
+    }
+
+    /**
+     * HMAC256 알고리즘을 생성합니다.
+     *
+     * @param secretKey JWT 비밀 키
+     * @return HMAC256 알고리즘
+     */
+    private static Algorithm generateAlgorithm(String secretKey) {
+
+        return Algorithm.HMAC256(secretKey.getBytes());
+    }
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/auth/UserDetailsImpl.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/auth/UserDetailsImpl.java
@@ -1,0 +1,54 @@
+package com.smile.fridaymarket_auth.domain.auth;
+
+
+import com.smile.fridaymarket_auth.domain.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public record UserDetailsImpl(User user) implements UserDetails {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return false;
+    }
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/auth/UserDetailsServiceImpl.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/auth/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.smile.fridaymarket_auth.domain.auth;
+
+
+import com.smile.fridaymarket_auth.domain.user.entity.User;
+import com.smile.fridaymarket_auth.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl {
+
+    private final UserRepository userRepository;
+
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("가입되지 않은 아이디입니다."));
+
+        return new UserDetailsImpl(user);
+    }
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/controller/UserController.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.smile.fridaymarket_auth.domain.user.controller;
 
+import com.smile.fridaymarket_auth.domain.auth.UserDetailsImpl;
 import com.smile.fridaymarket_auth.domain.user.dto.LoginRequest;
 import com.smile.fridaymarket_auth.domain.user.dto.UserCreateRequest;
+import com.smile.fridaymarket_auth.domain.user.dto.UserInfo;
 import com.smile.fridaymarket_auth.domain.user.service.UserService;
 import com.smile.fridaymarket_auth.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -41,5 +44,11 @@ public class UserController {
         return ResponseEntity.status(200).headers(httpHeaders).body(response);
     }
 
+    @Operation(summary = "회원 정보 조회", description = "회원 정보 조회")
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    public SuccessResponse<UserInfo> getUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        return SuccessResponse.successWithData(userService.getUserInfo(userDetails.getUsername()));
+    }
 
 }

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/dto/UserInfo.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/dto/UserInfo.java
@@ -1,0 +1,21 @@
+package com.smile.fridaymarket_auth.domain.user.dto;
+
+import com.smile.fridaymarket_auth.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserInfo {
+
+    private String username;
+    private String phoneNumber;
+
+    public static UserInfo fromEntity(User user) {
+        return UserInfo.builder()
+                .username(user.getUsername())
+                .phoneNumber(user.getPhoneNumber())
+                .build();
+    }
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserReader.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserReader.java
@@ -8,4 +8,6 @@ public interface UserReader {
 
     User getUser(String username, String password);
 
+    User getUserByUsername(String username);
+
 }

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserReaderImpl.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserReaderImpl.java
@@ -50,6 +50,20 @@ public class UserReaderImpl implements UserReader {
     }
 
     /**
+     * 유저 아이디로 유저 객체 검증
+     *
+     * @param username 사용자 아이디
+     * @return 해당 유저 객체 반환
+     */
+    @Override
+    public User getUserByUsername(String username) {
+
+        return userRepository.findByUsername(username).orElseThrow(
+                () -> new CustomException(ILLEGAL_USER_NOT_EXIST)
+        );
+    }
+
+    /**
      * 비밀번호 확인
      *
      * @param comparePassword 새로 입력한 비밀번호

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserService.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.smile.fridaymarket_auth.domain.user.service;
 
 import com.smile.fridaymarket_auth.domain.user.dto.LoginRequest;
 import com.smile.fridaymarket_auth.domain.user.dto.UserCreateRequest;
+import com.smile.fridaymarket_auth.domain.user.dto.UserInfo;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
@@ -12,5 +13,7 @@ public interface UserService {
     void signup(@Valid UserCreateRequest userCreateRequest);
 
     HttpHeaders login(LoginRequest loginRequest);
+
+    UserInfo getUserInfo(String username);
 
 }

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImpl.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.smile.fridaymarket_auth.domain.user.service;
 import com.smile.fridaymarket_auth.domain.auth.UserAuth;
 import com.smile.fridaymarket_auth.domain.user.dto.LoginRequest;
 import com.smile.fridaymarket_auth.domain.user.dto.UserCreateRequest;
+import com.smile.fridaymarket_auth.domain.user.dto.UserInfo;
 import com.smile.fridaymarket_auth.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -48,6 +49,22 @@ public class UserServiceImpl implements UserService {
         // 헤더에 Access 토큰 및 Refresh 토큰 생성 후 전달
         return userAuth.generateHeaderTokens(user);
 
+    }
+
+    /**
+     * 3. 회원정보 조회
+     *
+     * @param username 유저 아이디
+     * @return 해당 유저의 아이디와 전화번호가 담긴 UserInfo 반환
+     */
+    @Override
+    @Transactional
+    public UserInfo getUserInfo(String username) {
+
+        // 유저 아이디로 유저 검증 및 객체 조회
+        User userByUsername = userReader.getUserByUsername(username);
+
+        return UserInfo.fromEntity(userByUsername);
     }
 
 

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/config/WebSecurityConfig.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/config/WebSecurityConfig.java
@@ -1,7 +1,7 @@
 package com.smile.fridaymarket_auth.global.config;
 
 import com.smile.fridaymarket_auth.domain.auth.JwtAuthenticationFilter;
-import com.smile.fridaymarket_auth.domain.auth.token.TokenProvider;
+import com.smile.fridaymarket_auth.domain.auth.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,7 +27,7 @@ public class WebSecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
-    private final TokenProvider tokenProvider;
+    private final JwtTokenProvider jwtTokenProvider;
 
 
     @Bean
@@ -41,7 +41,7 @@ public class WebSecurityConfig {
                                 "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }


### PR DESCRIPTION
## 📌 작업 내용
- 유저의 AccessToken으로 알맞은 회원 정보를 반환하는 기능을 구현하였습니다.
- AccessToken 검증 시 만료된 토큰일 경우 401 에러 코드와 만료된 토큰임을 알리는 메세지를 반환합니다.
- 유효한 토큰인 경우에도 해당 유저의 정보가 가입되지 않은 정보일 경우에는 400 에러 코드와 가입되지 않은 유저임을 알리는 메세지를 반환합니다.

<br/>

## 🌱 반영 브랜치
- FM-5-feat/user-getInfo -> dev
- close #12 

<br/>
