### PR TITLE
[Test] 회원정보 조회 테스트

### DIFF
--- a/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/controller/UserControllerTest.java
+++ b/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/controller/UserControllerTest.java
@@ -1,24 +1,43 @@
 package com.smile.fridaymarket_auth.domain.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smile.fridaymarket_auth.domain.auth.UserDetailsImpl;
+import com.smile.fridaymarket_auth.domain.auth.token.service.JwtTokenUtils;
 import com.smile.fridaymarket_auth.domain.user.dto.LoginRequest;
 import com.smile.fridaymarket_auth.domain.user.dto.UserCreateRequest;
+import com.smile.fridaymarket_auth.domain.user.dto.UserInfo;
+import com.smile.fridaymarket_auth.domain.user.entity.User;
+import com.smile.fridaymarket_auth.domain.user.entity.UserRole;
+import com.smile.fridaymarket_auth.domain.user.repository.UserRepository;
 import com.smile.fridaymarket_auth.domain.user.service.UserService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.util.Set;
+
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UserController.class)
@@ -36,10 +55,43 @@ class UserControllerTest {
     @Autowired
     private LocalValidatorFactoryBean validator;
 
+    @MockBean
+    private PasswordEncoder passwordEncoder;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private JwtTokenUtils jwtTokenUtils;
+
+    @Mock
+    private UserDetailsImpl mockUserDetails;
+
+
     @BeforeEach
     void setUp() {
 
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+
+        MockitoAnnotations.openMocks(this);
+
+        User mockUser = User.builder()
+                .username("testUser")
+                .password(passwordEncoder.encode("testPassword!"))
+                .phoneNumber("01012345678")
+                .userRole(Set.of(UserRole.NORMAL))
+                .isDeleted(false)
+                .build();
+        userRepository.save(mockUser);
+
+        // "testUser" 계정명을 가진 UserDetails Mock 객체 설정
+        given(mockUserDetails.getUsername()).willReturn("testUser");
+
+        // SecurityContext에 UserDetails Mock 객체 설정 => SecurityContext에 Authentication 객체를 설정하여, 이후 테스트에서 인증된 사용자의 정보를 사용할 수 있도록 함
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        securityContext.setAuthentication(
+                new UsernamePasswordAuthenticationToken(mockUserDetails, null, mockUserDetails.getAuthorities()));
+
     }
 
     @AfterEach
@@ -51,77 +103,132 @@ class UserControllerTest {
     @DisplayName("형식에 맞지 않는 아이디로 회원가입을 진행합니다.")
     void signupWithNotValidUsername() throws Exception {
 
+        // given: 형식에 맞지 않는 아이디를 포함한 UserCreateRequest 객체를 생성합니다.
         UserCreateRequest request = UserCreateRequest.builder()
-                .username("te")  // 형식에 맞지 않는 아이디
+                .username("te")  // 3자리 미만의 아이디
                 .password("testPassword!")
-                .phoneNumber("01012345678").build();
+                .phoneNumber("01012345678")
+                .build();
 
-        mockMvc
-                .perform(post("/api/users")
+        // when & then: HTTP POST 요청을 수행하고, 상태 코드가 400(BadRequest)인지 확인합니다.
+        mockMvc.perform(post("/api/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request)))
-                .andExpect(status().isBadRequest()); // 예외가 발생해야 합니다.
+                .andExpect(status().isBadRequest());
     }
 
     @Test
     @DisplayName("형식에 맞지 않는 비밀번호로 회원가입을 진행합니다.")
     void signupWithNotValidPassword() throws Exception {
 
+        // given: 형식에 맞지 않는 비밀번호를 포함한 UserCreateRequest 객체를 생성합니다.
         UserCreateRequest request = UserCreateRequest.builder()
                 .username("testUser")
-                .password("short")  // 형식에 맞지 않는 비밀번호
-                .phoneNumber("01012345678").build();
+                .password("short")  // 비밀번호가 너무 짧음
+                .phoneNumber("01012345678")
+                .build();
 
+        // when & then: HTTP POST 요청을 수행하고, 상태 코드가 400(BadRequest)인지 확인합니다.
         mockMvc.perform(post("/api/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request)))
-                .andExpect(status().isBadRequest()); // 예외가 발생해야 합니다.
+                .andExpect(status().isBadRequest());
     }
 
     @Test
     @DisplayName("형식에 맞지 않는 전화번호로 회원가입을 진행합니다.")
     void signupWithNotValidPhoneNumber() throws Exception {
 
+        // given: 형식에 맞지 않는 전화번호를 포함한 UserCreateRequest 객체를 생성합니다.
         UserCreateRequest request = UserCreateRequest.builder()
                 .username("testUser")
                 .password("testPassword!")
-                .phoneNumber("invalidPhoneNumber")  // 형식에 맞지 않는 전화번호
+                .phoneNumber("invalidPhoneNumber")  // 유효하지 않은 전화번호
                 .build();
 
+        // when & then: HTTP POST 요청을 수행하고, 상태 코드가 400(BadRequest)인지 확인합니다.
         mockMvc.perform(post("/api/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request)))
-                .andExpect(status().isBadRequest()); // 예외가 발생해야 합니다.
+                .andExpect(status().isBadRequest());
     }
 
     @Test
     @DisplayName("형식에 맞지 않는 아이디로 로그인 합니다.")
     void loginWithNotValidUsername() throws Exception {
 
+        // given: 형식에 맞지 않는 아이디를 포함한 LoginRequest 객체를 생성합니다.
         LoginRequest request = LoginRequest.builder()
-                .username("te")  // 형식에 맞지 않는 아이디
+                .username("te")  // 3자리 미만의 아이디
                 .password("testPassword!")
                 .build();
 
-        mockMvc
-                .perform(post("/api/users/login")
+        // when & then: HTTP POST 요청을 수행하고, 상태 코드가 400(BadRequest)인지 확인합니다.
+        mockMvc.perform(post("/api/users/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request)))
-                .andExpect(status().isBadRequest()); // 예외가 발생해야 합니다.
+                .andExpect(status().isBadRequest());
     }
 
     @Test
     @DisplayName("형식에 맞지 않는 비밀번호로 로그인 합니다.")
     void loginWithNotValidPassword() throws Exception {
 
+        // given: 형식에 맞지 않는 비밀번호를 포함한 LoginRequest 객체를 생성합니다.
         LoginRequest request = LoginRequest.builder()
                 .username("testUser")
-                .password("short") // 형식에 맞지 않는 비밀번호
+                .password("short")  // 형식에 맞지 않는 비밀번호
                 .build();
 
+        // when & then: HTTP POST 요청을 수행하고, 상태 코드가 400(BadRequest)인지 확인합니다.
         mockMvc.perform(post("/api/users/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request)))
-                .andExpect(status().isBadRequest()); // 예외가 발생해야 합니다.
+                .andExpect(status().isBadRequest());
     }
+
+    @Test
+    @DisplayName("회원정보 조회 해피 케이스 테스트를 진행합니다.")
+    void getUserInfoWithSuccess() throws Exception {
+        // given: 테스트에 사용할 유저를 생성 및 저장합니다.
+        User user = User.builder()
+                .username("testUser")
+                .password(passwordEncoder.encode("testPassword!"))
+                .phoneNumber("01012345678")
+                .userRole(Set.of(UserRole.NORMAL))
+                .isDeleted(false)
+                .build();
+        userRepository.save(user);
+
+        UserInfo userInfo = UserInfo.builder()
+                .username("testUser")
+                .phoneNumber("01012345678")
+                .build();
+
+        // Mock 서비스 응답
+        given(userService.getUserInfo("testUser")).willReturn(userInfo);
+
+        // given: 임시 AccessToken을 생성합니다.
+        String token = "Bearer " + generateTokenForUser(user);
+
+
+        // when & then: HTTP GET 요청을 수행하고, 상태 코드가 200(OK)인지 확인하며, 응답의 data 필드에 유저 정보가 포함되어 있는지 검증합니다.
+        mockMvc.perform(get("/api/users")
+                        .header(HttpHeaders.AUTHORIZATION, token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true)) // 응답의 success 필드 확인
+                .andExpect(jsonPath("$.message").value("OK")) // 응답의 message 필드 확인
+                .andExpect(jsonPath("$.data.username").value(user.getUsername())) // data 안의 username 확인
+                .andExpect(jsonPath("$.data.phoneNumber").value(user.getPhoneNumber())); // data 안의 phoneNumber 확인
+
+    }
+
+
+    // AccessToken 생성
+    private String generateTokenForUser(User user) {
+
+        return jwtTokenUtils.generateAccessToken(user.getUsername());
+    }
+
 }

--- a/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImplTest.java
+++ b/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImplTest.java
@@ -8,21 +8,23 @@ import com.smile.fridaymarket_auth.domain.user.repository.UserRepository;
 import com.smile.fridaymarket_auth.global.exception.CustomException;
 import com.smile.fridaymarket_auth.global.exception.ErrorCode;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.validation.BindException;
 
-import java.util.Base64;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -165,4 +167,22 @@ class UserServiceImplTest {
         assertEquals(ErrorCode.ILLEGAL_PASSWORD_NOT_VALID, exception.getErrorCode());
     }
 
+    @Test
+    @DisplayName("가입되지 않은 유저의 정보를 조회합니다.")
+    void getUserInfoWithNotExistUser() {
+        // given: 테스트에 사용할 유저를 생성 및 저장합니다.
+        User user = User.builder()
+                .username("testUser")
+                .password(passwordEncoder.encode("testPassword!"))
+                .phoneNumber("01012345678")
+                .userRole(Set.of(UserRole.NORMAL))
+                .isDeleted(false)
+                .build();
+        userRepository.save(user);
+
+        // when && then : 가입되지 않은 유저 아이디로 회원 정보 조회 시도 시 해당 에러 메세지와 함께 예외가 발생합니다.
+        CustomException exception = assertThrows(CustomException.class, () -> userService.getUserInfo("NotExistUser"));
+        assertEquals(ErrorCode.ILLEGAL_USER_NOT_EXIST, exception.getErrorCode());
+
+    }
 }

--- a/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImplTest.java
+++ b/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImplTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -21,10 +20,6 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @ActiveProfiles("test")


### PR DESCRIPTION
## 📌 작업 내용
- UserControllerTest 클래스에서 토큰을 받아와 해당 유저의 정보를 조회하는 해피 케이스 테스트를 진행하였습니다.
- `jwtTokenUtils` 클래스를 `Mock객체로 생성`하여 토큰을 임시로 생성하고 해당 토큰을 검증하였습니다.
- 가입되지 않은 아이디로 회원정보 조회 시 발생하는 예외 케이스 테스트 진행하였습니다.

<br/>

## 🌱 반영 브랜치
- FM-7-test/user-getInfo -> dev
- close #13 

<br>