### PR TITLE
[Feat] 회원정보 수정 기능 구현

### DIFF
--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/controller/UserController.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.smile.fridaymarket_auth.domain.auth.UserDetailsImpl;
 import com.smile.fridaymarket_auth.domain.user.dto.LoginRequest;
 import com.smile.fridaymarket_auth.domain.user.dto.UserCreateRequest;
 import com.smile.fridaymarket_auth.domain.user.dto.UserInfo;
+import com.smile.fridaymarket_auth.domain.user.dto.UserUpdateRequest;
 import com.smile.fridaymarket_auth.domain.user.service.UserService;
 import com.smile.fridaymarket_auth.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,6 +50,14 @@ public class UserController {
     public SuccessResponse<UserInfo> getUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         return SuccessResponse.successWithData(userService.getUserInfo(userDetails.getUsername()));
+    }
+
+    @Operation(summary = "회원 정보 수정", description = "회원 정보 수정")
+    @RequestMapping(value = "", method = RequestMethod.PATCH)
+    public SuccessResponse<UserInfo> updateUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                    @Valid @RequestBody UserUpdateRequest updateRequest) {
+
+        return SuccessResponse.successWithData(userService.updateUserInfo(userDetails.getUsername(), updateRequest));
     }
 
 }

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/dto/UserUpdateRequest.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/dto/UserUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.smile.fridaymarket_auth.domain.user.dto;
+
+import com.smile.fridaymarket_auth.domain.user.entity.User;
+import com.smile.fridaymarket_auth.domain.user.service.validation.ValidPhoneNumber;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUpdateRequest {
+    @NotBlank(message = "전화번호는 필수 입력 값입니다.")
+    @ValidPhoneNumber
+    private String phoneNumber;
+
+    public User toEntity(User updateUser) {
+
+        return User.builder()
+                .username(updateUser.getUsername())
+                .password(updateUser.getPassword())
+                .phoneNumber(this.phoneNumber)
+                .userRole(updateUser.getUserRole())
+                .isDeleted(updateUser.getIsDeleted())
+                .build();
+    }
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/entity/User.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.smile.fridaymarket_auth.domain.user.entity;
 
+import com.smile.fridaymarket_auth.domain.user.dto.UserUpdateRequest;
 import com.smile.fridaymarket_auth.global.entity.Timestamped;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -40,5 +41,13 @@ public class User extends Timestamped {
 
     @Column(name = "IS_DELETED", nullable = false)
     private Boolean isDeleted = false;
+
+    public void update(User updateUser) {
+        this.username = updateUser.getUsername();
+        this.password = updateUser.getPassword();;
+        this.phoneNumber = updateUser.getPhoneNumber();
+        this.userRole = updateUser.getUserRole();
+        this.isDeleted = updateUser.getIsDeleted();
+    }
 
 }

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/entity/User.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/entity/User.java
@@ -42,12 +42,9 @@ public class User extends Timestamped {
     @Column(name = "IS_DELETED", nullable = false)
     private Boolean isDeleted = false;
 
-    public void update(User updateUser) {
-        this.username = updateUser.getUsername();
-        this.password = updateUser.getPassword();;
-        this.phoneNumber = updateUser.getPhoneNumber();
-        this.userRole = updateUser.getUserRole();
-        this.isDeleted = updateUser.getIsDeleted();
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+
     }
 
 }

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserService.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.smile.fridaymarket_auth.domain.user.service;
 import com.smile.fridaymarket_auth.domain.user.dto.LoginRequest;
 import com.smile.fridaymarket_auth.domain.user.dto.UserCreateRequest;
 import com.smile.fridaymarket_auth.domain.user.dto.UserInfo;
+import com.smile.fridaymarket_auth.domain.user.dto.UserUpdateRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
@@ -15,5 +16,7 @@ public interface UserService {
     HttpHeaders login(LoginRequest loginRequest);
 
     UserInfo getUserInfo(String username);
+
+    UserInfo updateUserInfo(String username, UserUpdateRequest updateRequest);
 
 }

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImpl.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImpl.java
@@ -4,6 +4,7 @@ import com.smile.fridaymarket_auth.domain.auth.UserAuth;
 import com.smile.fridaymarket_auth.domain.user.dto.LoginRequest;
 import com.smile.fridaymarket_auth.domain.user.dto.UserCreateRequest;
 import com.smile.fridaymarket_auth.domain.user.dto.UserInfo;
+import com.smile.fridaymarket_auth.domain.user.dto.UserUpdateRequest;
 import com.smile.fridaymarket_auth.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -67,5 +68,23 @@ public class UserServiceImpl implements UserService {
         return UserInfo.fromEntity(userByUsername);
     }
 
+    /**
+     * 4. 회원정보 수정
+     *
+     * @param username 유저 아이디
+     * @param updateRequest 변경하려는 전화번호
+     * @return 변경된 전화번호와 해당 유저의 아이디 값을 반환
+     */
+    @Override
+    @Transactional
+    public UserInfo updateUserInfo(String username, UserUpdateRequest updateRequest) {
+        // 유저 아이디로 유저 검증 및 객체 조회
+        User updateUser = userReader.getUserByUsername(username);
+        // 정보 업데이트
+        User initUser = updateRequest.toEntity(updateUser);
+        updateUser.update(initUser);
+        // 아이디와 수정된 전화번호를 담아 반환
+        return UserInfo.fromEntity(updateUser);
+    }
 
 }

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImpl.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImpl.java
@@ -80,10 +80,11 @@ public class UserServiceImpl implements UserService {
     public UserInfo updateUserInfo(String username, UserUpdateRequest updateRequest) {
         // 유저 아이디로 유저 검증 및 객체 조회
         User updateUser = userReader.getUserByUsername(username);
-        // 정보 업데이트
-        User initUser = updateRequest.toEntity(updateUser);
-        updateUser.update(initUser);
-        // 아이디와 수정된 전화번호를 담아 반환
+
+        // 유효성 검사 통과한 전화번호만 업데이트
+        updateUser.updatePhoneNumber(updateRequest.getPhoneNumber());
+
+        // 유저 정보 반환 (자동으로 영속성 컨텍스트가 변경 사항을 감지하여 DB에 반영)
         return UserInfo.fromEntity(updateUser);
     }
 


### PR DESCRIPTION
## 📌 작업 내용
- 유저의 전화번호만 수정
 :  유저의 username 필드는 unique 제약이 걸려 있고, 비밀번호 또한 변경하지 않기에, 오직 전화번호만 수정이 가능하도록 하였습니다.

- 전화번호 유효성 검증
 : 사용자가 입력한 전화번호가 유효하지 않을 경우, 400 에러 코드를 반환하며, 함께 적절한 에러 메시지를 클라이언트에 전달합니다.

- ```Dirty Checking```을 활용한 효율적인 업데이트
 : 영속성 컨텍스트를 사용하여 변경된 필드만 자동으로 감지하고 업데이트하는 dirty checking 메커니즘을 통해 수정 기능을 구현했습니다. 이를 통해 불필요한 객체 생성 없이 성능을 최적화했습니다.

<br/>

## 🌱 반영 브랜치
- FM-8-feat/user-update -> dev
- close #17 

<br/>