### PR TITLE
[Feat] RefreshToken으로 AccessToken 재발급 기능 구현

### DIFF
--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/controller/TokenController.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/domain/user/controller/TokenController.java
@@ -1,0 +1,25 @@
+package com.smile.fridaymarket_auth.domain.user.controller;
+
+import com.smile.fridaymarket_auth.domain.auth.token.service.RefreshTokenManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TokenController {
+
+    private final RefreshTokenManager refreshTokenManager;
+
+    @GetMapping("/api/refresh")
+    public ResponseEntity<HttpHeaders> refreshAccessToken(@RequestHeader("RefreshToken") String refreshToken) {
+
+        HttpHeaders headers = refreshTokenManager.refreshAccessToken(refreshToken);
+        return ResponseEntity.status(HttpStatus.OK).headers(headers).body(null);
+    }
+
+}

--- a/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/config/WebSecurityConfig.java
+++ b/fridaymarket_auth/src/main/java/com/smile/fridaymarket_auth/global/config/WebSecurityConfig.java
@@ -29,7 +29,6 @@ public class WebSecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
@@ -38,7 +37,7 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.POST, ("/api/users/**")).permitAll()
                         .requestMatchers("/swagger-ui/**",
-                                "/swagger-ui.html").permitAll()
+                                "/swagger-ui.html", "/api/refresh").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImplTest.java
+++ b/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImplTest.java
@@ -225,9 +225,7 @@ class UserServiceImplTest {
                 .build();
 
         // when & then: DB에 유저가 존재하지 않을 때 400 에러코드와 해당 에러 메세지와 함께 예외가 발생합니다.
-        CustomException exception = assertThrows(CustomException.class, () -> {
-            userService.updateUserInfo(nonExistentUsername, request);
-        });
+        CustomException exception = assertThrows(CustomException.class, () -> userService.updateUserInfo(nonExistentUsername, request));
         assertEquals(ErrorCode.ILLEGAL_USER_NOT_EXIST, exception.getErrorCode());
 
     }


### PR DESCRIPTION
## 📌 작업 내용
- 유저의 RefreshToken을 받아 유효성 검증을 합니다.
- 만약 RefreshToken 유효성 검사 실패 시 ```유효하지 않은 RefreshToken 입니다.``` 에러 메세지와 400에러 코드를 반환합니다.

<br/>

## 🌱 반영 브랜치
- FM-10-feat/user-refresh
- close #19 

<br/>

## 🔥 트러블 슈팅
- 현재 WebSecurityConfig 클래스에서 해당 기능을 호출하는 API의 엔드포인트를 허용한 상태입니다.
- 지금까지의 코드 상에는 RefreshToken을 저장할 때 유저의 IP나 로그인 시의 유저의 위도 경도 등 보다 세부적인 정보를 저장하고 있지 않기 때문에 탈취당할 경우 보안에 취약하다는 판단이 들어 추후에는 `만료된 AccessToken도 함께 받아야 재발급` 받을 수 있도록 수정하면 좋겠다는 생각을 하였습니다.
