### PR TITLE
[Test] AccessToken 재발급 테스트

### DIFF
--- a/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/controller/TokenControllerTest.java
+++ b/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/controller/TokenControllerTest.java
@@ -3,14 +3,12 @@ package com.smile.fridaymarket_auth.domain.user.controller;
 import com.smile.fridaymarket_auth.domain.auth.token.service.RefreshTokenManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.Mockito.when;
@@ -18,7 +16,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
 @WebMvcTest(TokenController.class)
 public class TokenControllerTest {
 

--- a/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/controller/TokenControllerTest.java
+++ b/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/controller/TokenControllerTest.java
@@ -1,0 +1,53 @@
+package com.smile.fridaymarket_auth.domain.user.controller;
+
+import com.smile.fridaymarket_auth.domain.auth.token.service.RefreshTokenManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(TokenController.class)
+public class TokenControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RefreshTokenManager refreshTokenManager;
+
+    @MockBean
+    private SecurityFilterChain securityFilterChain;
+
+    @Test
+    @DisplayName("RefreshToken으로 AccessToken을 재발급합니다.")
+    void refreshAccessToken() throws Exception {
+        // given
+        String mockRefreshToken = "mockRefreshToken"; // 실제 JWT가 아닌 모킹된 토큰
+        String newAccessToken = "mockAccessToken"; // Mock에서 설정된 값 사용
+
+        // Mock 메서드 응답 설정
+        when(refreshTokenManager.refreshAccessToken(mockRefreshToken)).thenReturn(new HttpHeaders() {{
+            set(HttpHeaders.AUTHORIZATION, "Bearer " + newAccessToken);
+        }});
+
+        // when & then
+        mockMvc.perform(get("/api/refresh")
+                        .header("RefreshToken", mockRefreshToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.AUTHORIZATION, "Bearer " + newAccessToken));
+    }
+}

--- a/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/controller/UserControllerTest.java
+++ b/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/controller/UserControllerTest.java
@@ -71,7 +71,6 @@ class UserControllerTest {
     void setUp() {
 
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
-
         MockitoAnnotations.openMocks(this);
 
         User mockUser = User.builder()
@@ -90,7 +89,6 @@ class UserControllerTest {
         SecurityContext securityContext = SecurityContextHolder.getContext();
         securityContext.setAuthentication(
                 new UsernamePasswordAuthenticationToken(mockUserDetails, null, mockUserDetails.getAuthorities()));
-
     }
 
     @AfterEach
@@ -209,7 +207,6 @@ class UserControllerTest {
 
         // given: 임시 AccessToken을 생성합니다.
         String token = "Bearer " + generateTokenForUser(user);
-
 
         // when & then: HTTP GET 요청을 수행하고, 상태 코드가 200(OK)인지 확인하며, 응답의 data 필드에 유저 정보가 포함되어 있는지 검증합니다.
         mockMvc.perform(get("/api/users")

--- a/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/service/TokenVerifyTest.java
+++ b/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/service/TokenVerifyTest.java
@@ -1,0 +1,69 @@
+package com.smile.fridaymarket_auth.domain.user.service;
+
+import com.smile.fridaymarket_auth.domain.user.dto.LoginRequest;
+import com.smile.fridaymarket_auth.domain.user.entity.User;
+import com.smile.fridaymarket_auth.domain.user.entity.UserRole;
+import com.smile.fridaymarket_auth.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class TokenVerifyTest {
+
+    @Autowired
+    UserServiceImpl userService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("로그인 해피 케이스 테스트입니다.")
+    void loginWithSuccess() {
+
+        // given : 새 유저 객체 생성 및 저장합니다.
+        User user = User.builder()
+                .username("testUser")
+                .password(passwordEncoder.encode("testPassword!"))
+                .phoneNumber("01012345678")
+                .userRole(Set.of(UserRole.NORMAL))
+                .isDeleted(false)
+                .build();
+        userRepository.save(user);
+
+        LoginRequest loginRequest = LoginRequest.builder()
+                .username("testUser")
+                .password("testPassword!")
+                .build();
+
+        // when : 가입된 유저 정보로 로그인을 시도합니다.
+        HttpHeaders httpHeaders = userService.login(loginRequest);
+
+        // then : 헤더에 토큰이 발급됩니다.
+        assertNotNull(httpHeaders);
+
+        // 헤더에서 AccessToken 확인
+        String accessToken = httpHeaders.getFirst(HttpHeaders.AUTHORIZATION);
+        assertNotNull(accessToken);
+        assertTrue(accessToken.startsWith("Bearer "));
+
+        // 헤더에서 RefreshToken 확인
+        String refreshToken = httpHeaders.getFirst("RefreshToken");
+        assertNotNull(refreshToken);
+
+    }
+
+}

--- a/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImplTest.java
+++ b/fridaymarket_auth/src/test/java/com/smile/fridaymarket_auth/domain/user/service/UserServiceImplTest.java
@@ -92,42 +92,6 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("로그인 해피 케이스 테스트입니다.")
-    void loginWithSuccess() {
-
-        // given : 새 유저 객체 생성 및 저장합니다.
-        User user = User.builder()
-                .username("testUser")
-                .password(passwordEncoder.encode("testPassword!"))
-                .phoneNumber("01012345678")
-                .userRole(Set.of(UserRole.NORMAL))
-                .isDeleted(false)
-                .build();
-        userRepository.save(user);
-
-        LoginRequest loginRequest = LoginRequest.builder()
-                .username("testUser")
-                .password("testPassword!")
-                .build();
-
-        // when : 가입된 유저 정보로 로그인을 시도합니다.
-        HttpHeaders httpHeaders = userService.login(loginRequest);
-
-        // then : 헤더에 토큰이 발급됩니다.
-        assertNotNull(httpHeaders);
-
-        // 헤더에서 AccessToken 확인
-        String accessToken = httpHeaders.getFirst(HttpHeaders.AUTHORIZATION);
-        assertNotNull(accessToken);
-        assertTrue(accessToken.startsWith("Bearer "));
-
-        // 헤더에서 RefreshToken 확인
-        String refreshToken = httpHeaders.getFirst("RefreshToken");
-        assertNotNull(refreshToken);
-
-    }
-
-    @Test
     @DisplayName("가입되지 않은 아이디로 로그인 합니다.")
     void loginWithNotExistUsername() {
         // given : 가입되지 않은 로그인 request 생성합니다.


### PR DESCRIPTION
## 📌 작업 내용
- RefreshToken으로 AccessToken 재발급하는 기능 테스트하였습니다.
- 실제 값이 아닌 mock에서 설정된 값으로 테스트 구현하였습니다.
- 테스트는 mockMvc.perform(get("/api/refresh")라는 특정 엔드포인트로 요청을 보낼 때 예상되는 상태 코드와 헤더 값을 테스트하였습니다.

<br/>

## 🌱 반영 브랜치
- FM-11-test/user-refresh -> dev
- close #20 

<br/>

## 🔥 트러블 슈팅

### 문제 상황
- 문제 원인: 테스트 중 401 Unauthorized와 404 Not Found 오류가 발생했습니다. 이는 JWT 토큰 생성, Redis 연동, 컨트롤러 핸들링 로직 등이 올바르게 설정되지 않은 탓이었습니다.
- 해결 방법: Mock 객체를 사용해 의존성을 줄이고, 실제 환경과 유사하게 동작하도록 테스트를 수정했습니다. 최종적으로 TokenControllerTest에서 RefreshToken을 이용한 AccessToken 재발급을 검증했습니다.

<details>
<summary>오류가 발생한 코드 및 발생 원인 분석</summary>
<div markdown="1">
    <div>

```
@Test
    @DisplayName("RefreshToken으로 AccessToken을 재발급합니다.")
    void refreshAccessToken() throws Exception {
        // given: 유저 정보를 미리 생성합니다.
        User user = User.builder()
                .username("testUser")
                .password(passwordEncoder.encode("testPassword!"))
                .phoneNumber("01012345678")
                .userRole(Set.of(UserRole.NORMAL))
                .isDeleted(false)
                .build();
        userRepository.save(user);

        // given: AccessToken과 RefreshToken을 미리 생성합니다.
        String refreshToken = jwtTokenUtils.generateRefreshToken(user.getUsername());
        String accessToken = jwtTokenUtils.generateAccessToken(user.getUsername());

        // given: Redis에 RefreshToken 저장 (가정)
        redisTemplate.opsForValue().set(user.getUsername(), refreshToken);

        // when & then: RefreshToken을 이용해 AccessToken을 재발급하는 요청을 보냅니다.
        mockMvc.perform(get("/api/refresh")
                        .header("RefreshToken" + refreshToken)
                        .contentType(MediaType.APPLICATION_JSON))
                .andExpect(status().isOk()) // 상태 코드 200을 확인합니다.
                .andExpect(jsonPath("$.success").value(true)); // 응답의 success 필드 확인
    }
```

- @MockBean을 통해 JwtTokenUtils와 RedisTemplate 같은 외부 서비스와의 의존성을 줄이고, 이를 가상화한 방식으로 테스트를 구성하였습니다.
- 하지만 그로 인해 generateRefreshToken() 함수로 만들어지는 refreshToken이 `null을 반환`하여 테스트가 실패하게 됩니다.

</div>
</details>

<details>
<summary>2차로 수정한 코드 및  발생 원인 분석</summary>
<div markdown="1">
    <div>

```
@WebMvcTest(UserController.class)
@ActiveProfiles("test")
class UserControllerTest {

    @Autowired
    private MockMvc mockMvc;

    @Autowired
    private WebApplicationContext webApplicationContext;

    @MockBean
    private UserService userService;
    
    @MockBean
    private JwtTokenUtils jwtTokenUtils;

    @MockBean
    private RedisTemplate<String, Object> redisTemplate;

    @MockBean
    private ValueOperations<String, Object> valueOperations;

    @BeforeEach
    void setUp() {
        // RedisTemplate의 opsForValue 메서드가 Mock으로 동작하도록 설정
        when(redisTemplate.opsForValue()).thenReturn(valueOperations);

        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
        
        // JwtTokenUtils Mock 동작 설정
        when(jwtTokenUtils.generateRefreshToken("testUser")).thenReturn("mockRefreshToken");
        when(jwtTokenUtils.generateAccessToken("testUser")).thenReturn("mockAccessToken");
         ...
    }

    @Test
    @DisplayName("RefreshToken으로 AccessToken을 재발급합니다.")
    void refreshAccessToken() throws Exception {
        // given: 유저 정보를 미리 생성합니다.
        User user = User.builder()
                .username("testUser")
                .password("testPassword!")
                .phoneNumber("01012345678")
                .userRole(Set.of(UserRole.NORMAL))
                .isDeleted(false)
                .build();
        userRepository.save(user);

        // given: RefreshToken과 AccessToken 값을 미리 생성합니다.
        String refreshToken = "mockRefreshToken";  // Mock에서 설정된 값 사용
        System.out.println("refreshToken = " + refreshToken);

        // given: Redis에 RefreshToken 저장 (가정)
        when(redisTemplate.opsForValue().get("testUser")).thenReturn(refreshToken);
        System.out.println("Stored RefreshToken in Redis for user: " + user.getUsername());

        // when & then: RefreshToken을 이용해 AccessToken을 재발급하는 요청을 보냅니다.
        mockMvc.perform(get("/api/refresh")
                        .header("RefreshToken", refreshToken)
                        .contentType(MediaType.APPLICATION_JSON))
                .andExpect(status().isOk())
                .andExpect(jsonPath("$.success").value(true));
    }
}
```

> 수정한 코드로 발생한 오류

```
refreshToken = mockRefreshToken
Stored RefreshToken in Redis for user: testUser

Status expected:<200> but was:<404>
Expected :200
Actual   :404
```

- 수정한 코드에서도 404 Not Found 오류가 발생했습니다. 이는 Mock 설정의 문제로 인해 UserControllerTest에 과도한 의존성이 발생한 탓이었습니다.


</div>
</details>

<br>

> UserControllerTest에 지나치게 많은 테스트가 몰리는 것을 피하는 게 좋다고 판단하였고, 각각의 책임에 맞는 컨트롤러를 테스트하도록 구분하고 유지보수성과 가독성을 높이기 위해 TokenControllerTest를 별도로 생성하여 테스트를 진행하였습니다.

<br>

<details>
<summary>최종 수정하여 해결한 코드</summary>
<div markdown="1">
    <div>

```
@WebMvcTest(TokenController.class)
public class TokenControllerTest {

    @Autowired
    private MockMvc mockMvc;

    @MockBean
    private RefreshTokenManager refreshTokenManager;

    @MockBean
    private SecurityFilterChain securityFilterChain;

    @Test
    @DisplayName("RefreshToken으로 AccessToken을 재발급합니다.")
    void refreshAccessToken() throws Exception {
        // given
        String mockRefreshToken = "mockRefreshToken"; // 실제 JWT가 아닌 모킹된 토큰
        String newAccessToken = "mockAccessToken"; // Mock에서 설정된 값 사용

        // Mock 메서드 응답 설정
        when(refreshTokenManager.refreshAccessToken(mockRefreshToken)).thenReturn(new HttpHeaders() {{
            set(HttpHeaders.AUTHORIZATION, "Bearer " + newAccessToken);
        }});

        // when & then
        mockMvc.perform(get("/api/refresh")
                        .header("RefreshToken", mockRefreshToken)
                        .contentType(MediaType.APPLICATION_JSON))
                .andExpect(status().isOk())
                .andExpect(header().string(HttpHeaders.AUTHORIZATION, "Bearer " + newAccessToken));
    }
}
```

</div>
</details>

### 최종 해결 방법
- TokenControllerTest를 별도로 생성하여 컨트롤러의 동작을 테스트하며, Mock 객체를 사용해 RefreshToken의 처리를 가정하여 실제 JWT와 Redis 연동 없이 테스트를 진행했습니다. 
- 실제 Redis나 JWT 처리 로직을 Mock으로 대체하게 되어 더 빠른 테스트 수행이 가능하였습니다.