### PR TITLE
[Feat] 주문 상태값 변경 로직 구현

### DIFF
--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/controller/OrderController.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/controller/OrderController.java
@@ -34,4 +34,34 @@ public class OrderController extends BaseController {
         return SuccessResponse.successWithNoData("입금 완료되었습니다.");
     }
 
+    @RequestMapping(value = "/{orderId}/isShipped", method = RequestMethod.PATCH)
+    public SuccessResponse<String> isShipped(@PathVariable Long orderId) {
+        orderService.isShipped(orderId);
+        return SuccessResponse.successWithNoData("발송 완료되었습니다.");
+    }
+
+    @RequestMapping(value = "/{orderId}/isReceived", method = RequestMethod.PATCH)
+    public SuccessResponse<String> isReceived(@PathVariable Long orderId) {
+        orderService.isReceived(orderId);
+        return SuccessResponse.successWithNoData("수령 완료되었습니다.");
+    }
+
+    @RequestMapping(value = "/{orderId}/isPaymentSent", method = RequestMethod.PATCH)
+    public SuccessResponse<String> isPaymentSent(@PathVariable Long orderId) {
+        orderService.isPaymentSent(orderId);
+        return SuccessResponse.successWithNoData("송금 완료되었습니다.");
+    }
+
+    @RequestMapping(value = "/{orderId}/request/cancel", method = RequestMethod.POST)
+    public SuccessResponse<String> cancelRequestByUser(HttpServletRequest request, @PathVariable Long orderId) {
+        UserResponse user = getUser(request);
+        orderService.cancelRequestByUser(user.userId(), orderId);
+        return SuccessResponse.successWithNoData("주문 취소 요청 완료되었습니다.");
+    }
+
+    @RequestMapping(value = "/{orderId}/cancel", method = RequestMethod.PATCH)
+    public SuccessResponse<String> cancelOrder(@PathVariable Long orderId) {
+        orderService.cancelOrder(orderId);
+        return SuccessResponse.successWithNoData("주문 취소 되었습니다.");
+    }
 }

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/dto/OrderCreateRequest.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/dto/OrderCreateRequest.java
@@ -1,12 +1,11 @@
 package com.smile.fridaymarket_resource.domain.order.dto;
 
 import com.smile.fridaymarket_resource.domain.order.entity.enums.OrderType;
-import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
-import java.math.BigDecimal;
+import java.util.List;
 
 @Getter
 public class OrderCreateRequest {
@@ -14,16 +13,8 @@ public class OrderCreateRequest {
     @NotNull(message = "주문 형식은 필수 값입니다.")
     private OrderType orderType;
 
-    @NotNull(message = "상품 ID는 필수 값입니다.")
-    private Long productId;
-
-    @NotNull(message = "수량은 필수 값입니다.")
-    @DecimalMin(value = "3.75", inclusive = true, message = "수량은 최소 3.75 이상이어야 합니다.")
-    private BigDecimal quantity;
-
-    @NotNull(message = "가격은 필수 값입니다.")
-    @DecimalMin(value = "0.00", inclusive = true, message = "가격은 0 이상이어야 합니다.")
-    private BigDecimal price;
+    @NotNull(message = "주문 상품 목록은 필수 값입니다.")
+    private List<OrderProductRequest> orderProducts;
 
     @NotBlank(message = "배송지는 필수 값입니다.")
     private String deliveryAddress;

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/dto/OrderProductRequest.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/dto/OrderProductRequest.java
@@ -1,0 +1,23 @@
+package com.smile.fridaymarket_resource.domain.order.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+public class OrderProductRequest {
+
+    @NotNull(message = "상품 ID는 필수 값입니다.")
+    private Long productId;
+
+    @NotNull(message = "수량은 필수 값입니다.")
+    @DecimalMin(value = "3.75", inclusive = true, message = "수량은 최소 3.75 이상이어야 합니다.")
+    private BigDecimal quantity;
+
+    @NotNull(message = "가격은 필수 값입니다.")
+    @DecimalMin(value = "0.00", inclusive = true, message = "가격은 0 이상이어야 합니다.")
+    private BigDecimal price;
+
+}

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/entity/CancelRequest.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/entity/CancelRequest.java
@@ -1,0 +1,38 @@
+package com.smile.fridaymarket_resource.domain.order.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// 배송 완료 요청 엔티티
+@Entity
+@Table(name = "TB_CNACEL_REQUEST")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CancelRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private UUID userId;  // 요청한 사용자 ID
+
+    private Long orderId; // 주문 ID
+
+    private LocalDateTime requestedAt; // 요청 시간
+
+    private boolean isApproved; // 승인 여부 (관리자가 변경)
+
+    public void updateStatus() {
+        this.isApproved = true;
+
+    }
+
+}

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/entity/OrderInvoice.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/entity/OrderInvoice.java
@@ -16,7 +16,6 @@ import java.util.UUID;
 @Entity
 @Table(name = "TB_ORDER_INVOICE")
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -88,7 +87,6 @@ public class OrderInvoice extends Timestamped {
     public void updateStatusIsPaymentSent() {
 
         this.orderStatus = OrderStatus.PAYMENT_SENT;
-
     }
 
     // 주문 취소 상태 값 변경
@@ -97,6 +95,18 @@ public class OrderInvoice extends Timestamped {
         this.isDeleted = true;
         this.orderStatus = OrderStatus.CANCELED;
         this.softDelete();
+    }
+
+    // 계산된 주문 총액 업데이트
+    public void updateAmount(BigDecimal totalAmount) {
+
+        this.amount = totalAmount;
+    }
+
+    // 주문 번호 최종 업데이트
+    public void updateOrderNo(String orderNo) {
+
+        this.orderNo = orderNo;
     }
 
 }

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/entity/OrderInvoice.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/entity/OrderInvoice.java
@@ -2,16 +2,17 @@ package com.smile.fridaymarket_resource.domain.order.entity;
 
 import com.smile.fridaymarket_resource.domain.order.entity.enums.OrderStatus;
 import com.smile.fridaymarket_resource.domain.order.entity.enums.OrderType;
-import com.smile.fridaymarket_resource.domain.product.entity.Product;
 import com.smile.fridaymarket_resource.global.entity.Timestamped;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+
 @Entity
 @Table(name = "TB_ORDER_INVOICE")
 @Getter
@@ -26,7 +27,7 @@ public class OrderInvoice extends Timestamped {
     @Column(name = "ORDER_INVOICE_ID", nullable = false)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "ORDER_NO")
     private String orderNo;
 
     @Column(name = "USER_ID", nullable = false)
@@ -40,10 +41,6 @@ public class OrderInvoice extends Timestamped {
     @Column(name = "ORDER_STATUS", nullable = false)
     private OrderStatus orderStatus;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "PRODUCT_ID", nullable = false)
-    private Product product;
-
     @Column(name = "AMOUNT", precision = 10, scale = 2, nullable = false)
     private BigDecimal amount;
 
@@ -54,9 +51,14 @@ public class OrderInvoice extends Timestamped {
     @Builder.Default
     private Boolean isDeleted = false;
 
+    // OrderProduct와 일대다 관계 설정
+    @OneToMany(mappedBy = "orderInvoice", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<OrderProduct> orderProducts = new ArrayList<>();
+
     // 주문 저장 이후 orderNo 생성
     @PostPersist
     public void generateOrderNo() {
+
         String orderTypePrefix = orderType.toString(); // "BUY" or "SELL"
         String date = LocalDate.now().format(DateTimeFormatter.ofPattern("MMdd")); // 현재 날짜 (월일)
         String orderIdSuffix = String.format("%04d", this.id); // 주문 ID 값 형식 지정 (4자리)
@@ -66,7 +68,35 @@ public class OrderInvoice extends Timestamped {
 
     // 입금 완료 상태 값 변경
     public void updateStatusIsPaymentReceived() {
+
         this.orderStatus = OrderStatus.PAYMENT_RECEIVED;
+    }
+
+    // 발송 완료 상태 값 변경
+    public void updateStatusIsShipped() {
+
+        this.orderStatus = OrderStatus.SHIPPED;
+    }
+
+    // 수령 완료 상태 값 변경
+    public void updateStatusIsReceived() {
+
+        this.orderStatus = OrderStatus.RECEIVED;
+    }
+
+    // 송금 완료 상태 값 변경
+    public void updateStatusIsPaymentSent() {
+
+        this.orderStatus = OrderStatus.PAYMENT_SENT;
+
+    }
+
+    // 주문 취소 상태 값 변경
+    public void updateStatusCanceled() {
+
+        this.isDeleted = true;
+        this.orderStatus = OrderStatus.CANCELED;
+        this.softDelete();
     }
 
 }

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/entity/OrderProduct.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/entity/OrderProduct.java
@@ -6,12 +6,14 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.DecimalMin;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
 @Entity
 @Table(name = "TB_ORDER_PRODUCT")
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -27,7 +29,7 @@ public class OrderProduct {
     private OrderType orderType;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "ORDER_ID", nullable = false)
+    @JoinColumn(name = "ORDER_INVOICE_ID", nullable = false)
     private OrderInvoice orderInvoice;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/repository/CancelRequestRepository.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/repository/CancelRequestRepository.java
@@ -1,0 +1,11 @@
+package com.smile.fridaymarket_resource.domain.order.repository;
+
+import com.smile.fridaymarket_resource.domain.order.entity.CancelRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CancelRequestRepository extends JpaRepository<CancelRequest, Long> {
+
+    Optional<CancelRequest> findByOrderId(Long orderId);
+}

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderService.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderService.java
@@ -9,4 +9,14 @@ public interface OrderService {
 
     void isPaymentReceived(String userId, Long orderId);
 
+    void isShipped(Long orderId);
+
+    void isReceived(Long orderId);
+
+    void isPaymentSent(Long orderId);
+
+    void cancelRequestByUser(String userId, Long orderId);
+
+    void cancelOrder(Long orderId);
+
 }

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderServiceImpl.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderServiceImpl.java
@@ -36,34 +36,54 @@ public class OrderServiceImpl implements OrderService {
     private final OrderReader orderReader;
     private final CancelRequestRepository cancelRequestRepository;
 
+    /**
+     * 1. 주문 등록
+     *
+     * @param userId 유저 Id
+     * @param request 주문 타입, 상품 Id, 수량, g당 가격, 배송지 정보로 주문 등록 요청
+     */
     @Override
     @Transactional
     public void createOrder(String userId, OrderCreateRequest request) {
 
         // 주문서(OrderInvoice) 생성 및 저장
+        // 1-1. 사용자의 ID와 요청된 주문 정보를 바탕으로 새로운 주문서 객체를 생성하고 데이터베이스에 저장.
         OrderInvoice orderInvoice = orderStore.saveOrderInvoice(userId, request);
 
-        BigDecimal totalAmount = BigDecimal.ZERO; // 총 금액 계산
+        // 총 금액 계산을 위한 변수 초기화
+        // 1-2. 주문에 포함된 상품들의 총 금액을 계산하기 위해 초기값을 0으로 설정.
+        BigDecimal totalAmount = BigDecimal.ZERO;
 
         // 각 상품(OrderProduct)을 처리하고 저장
+        // 1-3. 요청된 주문에 포함된 각 상품을 하나씩 처리하기 위한 반복문 시작.
         for (OrderProductRequest productRequest : request.getOrderProducts()) {
+
             // 각 상품에 대해 Product 가져오기
+            // 1-4. productRequest에 담긴 productId를 이용하여 상품 정보를 조회.
             Product product = productReader.getProduct(productRequest.getProductId());
 
             // 기존 DB에서 해당 상품의 가격 가져오기
+            // 1-5. DB에서 해당 상품에 대한 가격 정보를 가져옴. 기존 Price DB에 같은 주문 타입과 가격이 존재한다면 해당 데이터를 사용
             Price price = priceReader.getPrice(productRequest.getPrice(), request.getOrderType(), userId);
 
-
+            // OrderProduct 객체 생성 및 저장
+            // 1-6. 상품 정보, 주문서 정보, 가격 및 요청된 상품 수량 등을 바탕으로 주문 상품(OrderProduct) 객체를 생성하고 저장.
             OrderProduct orderProduct = orderStore.saveOrderProduct(request, orderInvoice, product, price, productRequest);
 
             // 총 금액 합산
+            // 1-7. 상품의 가격과 수량을 곱한 값을 총 금액에 더함.
             totalAmount = totalAmount.add(orderProduct.getPrice().multiply(orderProduct.getQuantity()));
         }
 
         // 주문서 금액 업데이트
-        orderInvoice.setAmount(totalAmount);
+        // 1-8. 반복문을 통해 모든 상품의 총 금액을 계산한 후, 해당 금액을 주문서(OrderInvoice) 객체에 업데이트.
+        orderInvoice.updateAmount(totalAmount);
+
+        // 주문서 저장 (업데이트)
+        // 1-9. 금액이 업데이트된 주문서를 다시 데이터베이스에 저장.
         orderStore.saveOrderInvoice(orderInvoice);
     }
+
 
     /**
      * 2. 주문 상태값 변경 (입금 완료)
@@ -92,7 +112,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     /**
-     * 주문의 송장 입력 받았다는 가정 하에 주문에 대한 상태값을 발송 완료로 변경
+     * 3. 주문의 송장 입력 받았다는 가정 하에 주문에 대한 상태값을 발송 완료로 변경
      * TODO : 관리자만 가능, 권한 설정 필요
      * @param orderId 주문 Id
      */
@@ -112,7 +132,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     /**
-     * 관리자가 판매자가 보낸 상품을 수령완료 한 경우 주문에 대한 상태값을 수령 완료로 변경
+     * 4. 관리자가 판매자가 보낸 상품을 수령완료 한 경우 주문에 대한 상태값을 수령 완료로 변경
      * TODO : 관리자만 가능, 권한 설정 필요
      * @param orderId 주문 Id
      */
@@ -132,7 +152,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     /**
-     * 관리자가 판매자의 상품 검수 및 정상 상품의 경우 송금 완료 후 해당 주문의 상태값을 송금 완료로 변경
+     * 5. 관리자가 판매자의 상품 검수 및 정상 상품의 경우 송금 완료 후 해당 주문의 상태값을 송금 완료로 변경
      * TODO : 관리자만 가능, 권한 설정 필요
      * @param orderId 주문 Id
      */
@@ -152,7 +172,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     /**
-     * 사용자가 주문 취소 요청을 보냄, 취소 요청 객체 생성
+     * 6. 사용자가 주문 취소 요청을 보냄, 취소 요청 객체 생성
      *
      * @param userId 유저 Id
      * @param orderId 주문 Id
@@ -179,7 +199,7 @@ public class OrderServiceImpl implements OrderService {
     }
 
     /**
-     * 관리자가 주문 취소 요청을 확인하고 실제로 주문을 삭제하지는 않고 상태값만 변경
+     * 7. 관리자가 주문 취소 요청을 확인하고 실제로 주문을 삭제하지는 않고 상태값만 변경
      * TODO : 관리자만 가능, 권한 설정 필요
      * @param orderId 주문 Id
      */

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderServiceImpl.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderServiceImpl.java
@@ -1,7 +1,12 @@
 package com.smile.fridaymarket_resource.domain.order.service;
 
 import com.smile.fridaymarket_resource.domain.order.dto.OrderCreateRequest;
+import com.smile.fridaymarket_resource.domain.order.dto.OrderProductRequest;
+import com.smile.fridaymarket_resource.domain.order.entity.CancelRequest;
 import com.smile.fridaymarket_resource.domain.order.entity.OrderInvoice;
+import com.smile.fridaymarket_resource.domain.order.entity.OrderProduct;
+import com.smile.fridaymarket_resource.domain.order.entity.enums.OrderStatus;
+import com.smile.fridaymarket_resource.domain.order.repository.CancelRequestRepository;
 import com.smile.fridaymarket_resource.domain.price.entity.Price;
 import com.smile.fridaymarket_resource.domain.price.service.PriceReader;
 import com.smile.fridaymarket_resource.domain.product.entity.Product;
@@ -12,9 +17,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
-import static com.smile.fridaymarket_resource.global.exception.ErrorCode.ILLEGAL_ORDER_USER_NOT_MATCHED;
+import static com.smile.fridaymarket_resource.domain.order.entity.enums.OrderType.BUY;
+import static com.smile.fridaymarket_resource.domain.order.entity.enums.OrderType.SELL;
+import static com.smile.fridaymarket_resource.global.exception.ErrorCode.*;
 
 @Slf4j
 @Service
@@ -25,30 +34,36 @@ public class OrderServiceImpl implements OrderService {
     private final PriceReader priceReader;
     private final OrderStore orderStore;
     private final OrderReader orderReader;
+    private final CancelRequestRepository cancelRequestRepository;
 
-    /**
-     * 1. 주문 등록
-     *
-     * @param userId 유저 Id
-     * @param request 주문 타입, 상품 Id, g당 금액, 수량, 배송지로 주문 등록 요청
-     */
     @Override
     @Transactional
     public void createOrder(String userId, OrderCreateRequest request) {
 
-        // 상품 가져오기
-        Product product = productReader.getProduct(request.getProductId());
+        // 주문서(OrderInvoice) 생성 및 저장
+        OrderInvoice orderInvoice = orderStore.saveOrderInvoice(userId, request);
 
-        // 가격 가져오기 (DB에서 주문 타입과 가격이 같은 경우에는 기존 가격 사용)
-        Price price = priceReader.getPrice(request.getPrice(), request.getOrderType(), userId);
+        BigDecimal totalAmount = BigDecimal.ZERO; // 총 금액 계산
 
-        // 주문 생성 및 저장
-        OrderInvoice orderInvoice = orderStore.saveOrderInvoice(userId, request, product, price.getPrice());
+        // 각 상품(OrderProduct)을 처리하고 저장
+        for (OrderProductRequest productRequest : request.getOrderProducts()) {
+            // 각 상품에 대해 Product 가져오기
+            Product product = productReader.getProduct(productRequest.getProductId());
 
-        // OrderProduct 생성 및 저장
-        orderStore.saveOrderProduct(request, orderInvoice, product, price.getPrice());
+            // 기존 DB에서 해당 상품의 가격 가져오기
+            Price price = priceReader.getPrice(productRequest.getPrice(), request.getOrderType(), userId);
+
+
+            OrderProduct orderProduct = orderStore.saveOrderProduct(request, orderInvoice, product, price, productRequest);
+
+            // 총 금액 합산
+            totalAmount = totalAmount.add(orderProduct.getPrice().multiply(orderProduct.getQuantity()));
+        }
+
+        // 주문서 금액 업데이트
+        orderInvoice.setAmount(totalAmount);
+        orderStore.saveOrderInvoice(orderInvoice);
     }
-
 
     /**
      * 2. 주문 상태값 변경 (입금 완료)
@@ -66,8 +81,125 @@ public class OrderServiceImpl implements OrderService {
         // 2. 본인의 주문인지 체크
         verifyOrderOwnership(userId, orderInvoice);
 
+        // 3. 주문 상태가 '주문 완료'이면서 '구매 주문'인지 확인
+        if (!orderInvoice.getOrderStatus().equals(OrderStatus.ORDER_COMPLETE) || orderInvoice.getOrderType().equals(SELL)) {
+            throw new CustomException(ORDER_STATUS_NOT_ORDER_COMPLETED);
+        }
+
         // 3. 주문 완료 상태에서 결제가 완료되었다는 가정하에 자동으로 상태값 변경
         orderInvoice.updateStatusIsPaymentReceived();
+
+    }
+
+    /**
+     * 주문의 송장 입력 받았다는 가정 하에 주문에 대한 상태값을 발송 완료로 변경
+     * TODO : 관리자만 가능, 권한 설정 필요
+     * @param orderId 주문 Id
+     */
+    @Override
+    @Transactional
+    public void isShipped(Long orderId) {
+
+        // 1. 주문 존재 여부 확인
+        OrderInvoice orderInvoice = orderReader.getOrderInvoice(orderId);
+
+        // 2. 주문 상태가 '입금 완료'이면서 '구매 주문'인지 확인
+        if (!orderInvoice.getOrderStatus().equals(OrderStatus.PAYMENT_RECEIVED) || orderInvoice.getOrderType().equals(SELL))
+            throw new CustomException(ORDER_STATUS_NOT_PAYMENT_RECEIVED);
+
+        // 3. 상품에 대한 송장 입력되었다는 가정 하에 상태 변경
+        orderInvoice.updateStatusIsShipped();
+    }
+
+    /**
+     * 관리자가 판매자가 보낸 상품을 수령완료 한 경우 주문에 대한 상태값을 수령 완료로 변경
+     * TODO : 관리자만 가능, 권한 설정 필요
+     * @param orderId 주문 Id
+     */
+    @Override
+    @Transactional
+    public void isReceived(Long orderId) {
+
+        // 1. 주문 존재 여부 확인
+        OrderInvoice orderInvoice = orderReader.getOrderInvoice(orderId);
+
+        // 2. 주문 상태가 '주문 완료'이면서 '판매 주문'인지 확인
+        if (!orderInvoice.getOrderStatus().equals(OrderStatus.ORDER_COMPLETE) || orderInvoice.getOrderType().equals(BUY))
+            throw new CustomException(ORDER_STATUS_NOT_RECEIVED);
+
+        // 3. 검수센터에서 상품 수령했다는 가정 하에 상태 변경
+        orderInvoice.updateStatusIsReceived();
+    }
+
+    /**
+     * 관리자가 판매자의 상품 검수 및 정상 상품의 경우 송금 완료 후 해당 주문의 상태값을 송금 완료로 변경
+     * TODO : 관리자만 가능, 권한 설정 필요
+     * @param orderId 주문 Id
+     */
+    @Override
+    @Transactional
+    public void isPaymentSent(Long orderId) {
+
+        // 1. 주문 존재 여부 확인
+        OrderInvoice orderInvoice = orderReader.getOrderInvoice(orderId);
+
+        // 2. 주문 상태가 '수령 완료'이면서 '판매 주문'인지 확인
+        if (!orderInvoice.getOrderStatus().equals(OrderStatus.RECEIVED) || orderInvoice.getOrderType().equals(BUY))
+            throw new CustomException(ORDER_STATUS_NOT_PAYMENT_SENT);
+
+        // 3. 상품에 대한 금액 송금 완료 후 상태 변경
+        orderInvoice.updateStatusIsPaymentSent();
+    }
+
+    /**
+     * 사용자가 주문 취소 요청을 보냄, 취소 요청 객체 생성
+     *
+     * @param userId 유저 Id
+     * @param orderId 주문 Id
+     */
+    @Override
+    @Transactional
+    public void cancelRequestByUser(String userId, Long orderId) {
+
+        // 1. 주문 존재 여부 확인
+        OrderInvoice orderInvoice = orderReader.getOrderInvoice(orderId);
+
+        // 2. 본인의 주문인지 검증
+        verifyOrderOwnership(userId, orderInvoice);
+
+        // 3. 주문 취소 요청 객체 생성 및 저장
+        CancelRequest cancelRequest = CancelRequest.builder()
+                .userId(UUID.fromString(userId))
+                .orderId(orderId)
+                .requestedAt(LocalDateTime.now())
+                .isApproved(false)
+                .build();
+
+        cancelRequestRepository.save(cancelRequest);
+    }
+
+    /**
+     * 관리자가 주문 취소 요청을 확인하고 실제로 주문을 삭제하지는 않고 상태값만 변경
+     * TODO : 관리자만 가능, 권한 설정 필요
+     * @param orderId 주문 Id
+     */
+    @Override
+    @Transactional
+    public void cancelOrder(Long orderId) {
+
+        // 1. 주문 존재 여부 검증
+        OrderInvoice orderInvoice = orderReader.getOrderInvoice(orderId);
+
+        // 2. 취소 요청 확인
+        CancelRequest cancelRequest = cancelRequestRepository.findByOrderId(orderId).orElseThrow(
+                () -> new CustomException(CANCEL_REQUEST_NOT_FOUND)
+        );
+
+        // 3. 취소 요청에 대한 승인 완료 상태값 변경
+        cancelRequest.updateStatus();
+
+        // 4. 주문에 대한 상태값 취소 상태로 변경 및 softDelete 처리
+        orderInvoice.updateStatusCanceled();
 
     }
 

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderStore.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderStore.java
@@ -1,14 +1,18 @@
 package com.smile.fridaymarket_resource.domain.order.service;
 
 import com.smile.fridaymarket_resource.domain.order.dto.OrderCreateRequest;
+import com.smile.fridaymarket_resource.domain.order.dto.OrderProductRequest;
 import com.smile.fridaymarket_resource.domain.order.entity.OrderInvoice;
+import com.smile.fridaymarket_resource.domain.order.entity.OrderProduct;
+import com.smile.fridaymarket_resource.domain.price.entity.Price;
 import com.smile.fridaymarket_resource.domain.product.entity.Product;
 
-import java.math.BigDecimal;
-
 public interface OrderStore {
-    OrderInvoice saveOrderInvoice(String userId, OrderCreateRequest request, Product product, BigDecimal price);
 
-    void saveOrderProduct(OrderCreateRequest request, OrderInvoice orderInvoice, Product product, BigDecimal price);
+    OrderInvoice saveOrderInvoice(String userId, OrderCreateRequest request);
+
+    void saveOrderInvoice(OrderInvoice orderInvoice);
+
+    OrderProduct saveOrderProduct(OrderCreateRequest request, OrderInvoice orderInvoice, Product product, Price price, OrderProductRequest productRequest);
 
 }

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderStoreImpl.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderStoreImpl.java
@@ -53,7 +53,7 @@ public class OrderStoreImpl implements OrderStore {
         // 주문 번호 생성 및 설정
         String orderNo = generateOrderNo(orderInvoice.getId(), orderInvoice.getOrderType());
 
-        orderInvoice.setOrderNo(orderNo);
+        orderInvoice.updateOrderNo(orderNo);
 
         // 주문서 업데이트
         return orderInvoiceRepository.save(orderInvoice);

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderStoreImpl.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderStoreImpl.java
@@ -1,12 +1,14 @@
 package com.smile.fridaymarket_resource.domain.order.service;
 
 import com.smile.fridaymarket_resource.domain.order.dto.OrderCreateRequest;
+import com.smile.fridaymarket_resource.domain.order.dto.OrderProductRequest;
 import com.smile.fridaymarket_resource.domain.order.entity.OrderInvoice;
 import com.smile.fridaymarket_resource.domain.order.entity.OrderProduct;
 import com.smile.fridaymarket_resource.domain.order.entity.enums.OrderStatus;
 import com.smile.fridaymarket_resource.domain.order.entity.enums.OrderType;
 import com.smile.fridaymarket_resource.domain.order.repository.OrderInvoiceRepository;
 import com.smile.fridaymarket_resource.domain.order.repository.OrderProductRepository;
+import com.smile.fridaymarket_resource.domain.price.entity.Price;
 import com.smile.fridaymarket_resource.domain.product.entity.Product;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -28,65 +30,59 @@ public class OrderStoreImpl implements OrderStore {
     /**
      * 주문 저장
      *
-     * @param userId  유저 Id
-     * @param request 주문 타입, 상품 Id, g당 금액, 수량, 배송지
-     * @param product 상품
-     * @param price   g당 가격
+     * @param userId 유저 Id
+     * @param request 주문 타입, 상품, 수량, 금액, 배송지 데이터로 요청
      * @return 저장된 주문 객체 반환
      */
     @Override
     @Transactional
-    public OrderInvoice saveOrderInvoice(String userId, OrderCreateRequest request, Product product, BigDecimal price) {
+    public OrderInvoice saveOrderInvoice(String userId, OrderCreateRequest request) {
 
+        // 주문서(OrderInvoice) 생성
         OrderInvoice orderInvoice = OrderInvoice.builder()
                 .userId(UUID.fromString(userId))
                 .orderType(request.getOrderType())
                 .orderStatus(OrderStatus.ORDER_COMPLETE)
-                .product(product)
-                .amount(getTotalPrice(request.getQuantity(), price))
+                .amount(BigDecimal.ZERO) // 초기 금액 설정
                 .deliveryAddress(request.getDeliveryAddress())
                 .build();
 
+        // 주문서 저장
+        orderInvoiceRepository.save(orderInvoice);
+
         // 주문 번호 생성 및 설정
         String orderNo = generateOrderNo(orderInvoice.getId(), orderInvoice.getOrderType());
+
         orderInvoice.setOrderNo(orderNo);
 
+        // 주문서 업데이트
         return orderInvoiceRepository.save(orderInvoice);
     }
 
     /**
-     * 주문별 주문 타입과 상품의 가격 및 수량을 저장
+     * 이미 생성된 주문에 총 금액이 계산된 결과 값 포함된 상태의 객체 저장
      *
-     * @param request      주문 타입, 상품 Id, g당 금액, 수량, 배송지
-     * @param orderInvoice 주문 객체
-     * @param product      상품
-     * @param price        g당 가격
+     * @param orderInvoice 저장하려는 주문 객체
      */
     @Override
-    @Transactional
-    public void saveOrderProduct(OrderCreateRequest request, OrderInvoice orderInvoice, Product product, BigDecimal price) {
+    public void saveOrderInvoice(OrderInvoice orderInvoice) {
+        orderInvoiceRepository.save(orderInvoice);
+    }
 
+    @Override
+    @Transactional
+    public OrderProduct saveOrderProduct(OrderCreateRequest request, OrderInvoice orderInvoice, Product product, Price price, OrderProductRequest productRequest) {
+
+        // OrderProduct 생성 및 저장
         OrderProduct orderProduct = OrderProduct.builder()
                 .orderType(request.getOrderType())
                 .orderInvoice(orderInvoice)
                 .product(product)
-                .price(price)
-                .quantity(request.getQuantity())
+                .price(price.getPrice()) // 가격 설정
+                .quantity(productRequest.getQuantity())
                 .build();
 
-        orderProductRepository.save(orderProduct);
-    }
-
-    /**
-     * 주문 총액 계산
-     *
-     * @param quantity  수량 (g단위)
-     * @param unitPrice g당 가격
-     * @return 계산된 총액 반환
-     */
-    private BigDecimal getTotalPrice(BigDecimal quantity, BigDecimal unitPrice) {
-
-        return unitPrice.multiply(quantity);
+        return orderProductRepository.save(orderProduct);
     }
 
     /**
@@ -97,6 +93,7 @@ public class OrderStoreImpl implements OrderStore {
      * @return 생성된 주문번호 반환 (ex. SELL-0910-0001)
      */
     private String generateOrderNo(Long orderId, OrderType orderType) {
+
         // 주문 타입 (BUY, SELL) + 날짜(월일) + 주문 ID
         String date = LocalDateTime.now().format(DateTimeFormatter.ofPattern("MMdd"));
         return orderType.name() + "-" + date + "-" + String.format("%04d", orderId); // 주문 ID는 4자리 형식

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/price/service/PriceReaderImpl.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/price/service/PriceReaderImpl.java
@@ -16,7 +16,7 @@ public class PriceReaderImpl implements PriceReader {
     private final PriceStore priceStore;
 
     /**
-     * 가격 조회
+     * 가격 조회 (DB에서 주문 타입과 가격이 같은 경우에는 기존 가격을 사용, 없다면 새로 저장)
      *
      * @param price     g당 가격
      * @param orderType 주문 타입
@@ -25,7 +25,7 @@ public class PriceReaderImpl implements PriceReader {
      */
     @Override
     public Price getPrice(BigDecimal price, OrderType orderType, String userId) {
-        // 가격 가져오기 (DB에서 주문 타입과 가격이 같은 경우에는 기존 가격을 사용)
+
         return priceRepository.findByPriceAndOrderType(price, orderType)
                 .orElseGet(() -> priceStore.saveNewPrice(price, orderType, userId));
     }

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/global/exception/ErrorCode.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/global/exception/ErrorCode.java
@@ -14,7 +14,13 @@ public enum ErrorCode {
 
     // Order
     ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 주문입니다."),
-    ILLEGAL_ORDER_USER_NOT_MATCHED(HttpStatus.BAD_REQUEST, "본인의 주문만 조회가 가능합니다.");
+    ILLEGAL_ORDER_USER_NOT_MATCHED(HttpStatus.BAD_REQUEST, "본인의 주문만 조회가 가능합니다."),
+    ORDER_STATUS_NOT_ORDER_COMPLETED(HttpStatus.BAD_REQUEST, "입금 완료 상태로 변경 불가한 주문입니다."),
+    ORDER_STATUS_NOT_PAYMENT_RECEIVED(HttpStatus.BAD_REQUEST, "발송 완료 상태로 변경 불가한 주문입니다."),
+    ORDER_STATUS_NOT_RECEIVED(HttpStatus.BAD_REQUEST, "수령 완료 상태로 변경 불가한 주문입니다."),
+    ORDER_STATUS_NOT_PAYMENT_SENT(HttpStatus.BAD_REQUEST, "송금 완료 상태로 변경 불가한 주문입니다."),
+    CANCEL_REQUEST_NOT_FOUND(HttpStatus.BAD_REQUEST, "주문 취소 요청을 찾을 수 없습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📌 작업 내용
- 등록된 주문에 대한 상태값 변경 기능 구현하였습니다.
- 구매 주문의 경우 ```주문 완료```, ```입금 완료```, ```발송 완료``` 상태를 가지며,
    판매 주문의 경우 ```주문 완료```, ```수령 완료```, ```송금 완료``` 상태를 가집니다.
- 각각의 상태값은 선제되어야 하는 주문 상태인 경우에만 변경 가능하며, 추후 관리자 권한으로만 변경 가능하도록 수정 예정입니다.

- 주문 등록 시 상품 단건 등록만 가능하던 로직을 여러 건 주문이 가능하도록 수정하였습니다.
- Setter로 구현된 계산 총액 값 저장, 주문 번호 저장 로직을 영속성 컨텍스트 하에 업데이트할 수 있도록 수정하였습니다.
- 주문 취소의 경우 Timestamped 클래스에 구현한 softDelete() 함수를 호출하여, 실제 주문을 취소하는 것이 아닌 삭제된 시점을 등록하고 isDeleted 컬럼의 값을 true 로 수정하여 저장합니다.

<br/>

## 🌱 반영 브랜치
- FM-18-feat/order-updateStatus -> dev-sub
- close #33
- close #39 

<br/>

## 🔥 트러블 슈팅
- 상품을 여러 개 주문하는 경우 각각 상품의 가격과 수량을 곱합 가격의 합산을 총액으로 사용
- 주문 등록 과정을 세분화하여 주문 데이터 등록 시 총액 컬럼의 경우 0으로 초기화 된 값으로 저장한 후에 계산한 총액을 데이터에 저장하여 업데이트하는 방식으로 구현

<img src="https://github.com/user-attachments/assets/0d17b3a5-3bb0-4a10-9f69-7743c6433abd" alt="image" width="300"/>
