### PR TITLE
[Feat] 주문 상세 조회 기능 구현

### DIFF
--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/controller/OrderController.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/controller/OrderController.java
@@ -2,6 +2,7 @@ package com.smile.fridaymarket_resource.domain.order.controller;
 
 import com.smile.fridaymarket_resource.auth.UserResponse;
 import com.smile.fridaymarket_resource.domain.order.dto.OrderCreateRequest;
+import com.smile.fridaymarket_resource.domain.order.dto.OrderResponse;
 import com.smile.fridaymarket_resource.domain.order.service.OrderService;
 import com.smile.fridaymarket_resource.global.response.SuccessResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -63,5 +64,11 @@ public class OrderController extends BaseController {
     public SuccessResponse<String> cancelOrder(@PathVariable Long orderId) {
         orderService.cancelOrder(orderId);
         return SuccessResponse.successWithNoData("주문 취소 되었습니다.");
+    }
+
+    @RequestMapping(value = "/{orderId}", method = RequestMethod.GET)
+    public SuccessResponse<OrderResponse> getOrderInvoice(HttpServletRequest request, @PathVariable Long orderId) {
+        UserResponse user = getUser(request);
+        return SuccessResponse.successWithData(orderService.getOrderInvoice(user.userId(), orderId));
     }
 }

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/dto/OrderProductResponse.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/dto/OrderProductResponse.java
@@ -1,0 +1,20 @@
+package com.smile.fridaymarket_resource.domain.order.dto;
+
+import com.smile.fridaymarket_resource.domain.product.entity.ProductName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderProductResponse {
+
+    private ProductName productName;
+
+    private BigDecimal price;
+
+    private BigDecimal quantity;
+}

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/dto/OrderResponse.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/dto/OrderResponse.java
@@ -1,0 +1,44 @@
+package com.smile.fridaymarket_resource.domain.order.dto;
+
+import com.smile.fridaymarket_resource.domain.order.entity.enums.OrderStatus;
+import com.smile.fridaymarket_resource.domain.order.entity.enums.OrderType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderResponse {
+
+    private String orderNo;
+
+    private UUID userId;
+
+    private OrderType orderType;
+
+    private OrderStatus orderStatus;
+
+    private List<OrderProductResponse> productResponses;
+
+    private BigDecimal amount;
+
+    private String deliveryAddress;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
+    private boolean isDeleted;
+
+}
+

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/entity/OrderInvoice.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/entity/OrderInvoice.java
@@ -1,5 +1,7 @@
 package com.smile.fridaymarket_resource.domain.order.entity;
 
+import com.smile.fridaymarket_resource.domain.order.dto.OrderProductResponse;
+import com.smile.fridaymarket_resource.domain.order.dto.OrderResponse;
 import com.smile.fridaymarket_resource.domain.order.entity.enums.OrderStatus;
 import com.smile.fridaymarket_resource.domain.order.entity.enums.OrderType;
 import com.smile.fridaymarket_resource.global.entity.Timestamped;
@@ -12,6 +14,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Entity
 @Table(name = "TB_ORDER_INVOICE")
@@ -107,6 +110,32 @@ public class OrderInvoice extends Timestamped {
     public void updateOrderNo(String orderNo) {
 
         this.orderNo = orderNo;
+    }
+
+    // 주문 상세 조회 응답 객체 생성
+    public OrderResponse toResponseDto(OrderInvoice orderInvoice) {
+
+        // OrderProduct를 OrderProductResponse로 변환하여 리스트로 변환
+        List<OrderProductResponse> productResponseList = orderInvoice.getOrderProducts().stream()
+                .map(orderProduct -> new OrderProductResponse(
+                        orderProduct.getProduct().getProductName(),
+                        orderProduct.getPrice(),
+                        orderProduct.getQuantity()))
+                .collect(Collectors.toList());
+
+        return OrderResponse.builder()
+                .orderNo(orderInvoice.getOrderNo())
+                .userId(orderInvoice.getUserId())
+                .orderType(orderInvoice.getOrderType())
+                .orderStatus(orderInvoice.getOrderStatus())
+                .productResponses(productResponseList) // List<OrderProductResponse>로 변경된 부분
+                .amount(orderInvoice.getAmount())
+                .deliveryAddress(orderInvoice.getDeliveryAddress())
+                .createdAt(orderInvoice.getCreatedAt())
+                .updatedAt(orderInvoice.getUpdatedAt())
+                .deletedAt(orderInvoice.getDeletedAt())
+                .isDeleted(orderInvoice.getIsDeleted())
+                .build();
     }
 
 }

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderService.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.smile.fridaymarket_resource.domain.order.service;
 
 import com.smile.fridaymarket_resource.domain.order.dto.OrderCreateRequest;
+import com.smile.fridaymarket_resource.domain.order.dto.OrderResponse;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,5 +19,7 @@ public interface OrderService {
     void cancelRequestByUser(String userId, Long orderId);
 
     void cancelOrder(Long orderId);
+
+    OrderResponse getOrderInvoice(String userId, Long orderId);
 
 }

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderServiceImpl.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderServiceImpl.java
@@ -2,6 +2,7 @@ package com.smile.fridaymarket_resource.domain.order.service;
 
 import com.smile.fridaymarket_resource.domain.order.dto.OrderCreateRequest;
 import com.smile.fridaymarket_resource.domain.order.dto.OrderProductRequest;
+import com.smile.fridaymarket_resource.domain.order.dto.OrderResponse;
 import com.smile.fridaymarket_resource.domain.order.entity.CancelRequest;
 import com.smile.fridaymarket_resource.domain.order.entity.OrderInvoice;
 import com.smile.fridaymarket_resource.domain.order.entity.OrderProduct;
@@ -220,6 +221,27 @@ public class OrderServiceImpl implements OrderService {
 
         // 4. 주문에 대한 상태값 취소 상태로 변경 및 softDelete 처리
         orderInvoice.updateStatusCanceled();
+
+    }
+
+    /**
+     * 8. 주문 상세 조회
+     *
+     * @param userId 유저 Id
+     * @param orderId 주문 Id
+     * @return 조회 요청한 주문
+     */
+    @Override
+    public OrderResponse getOrderInvoice(String userId, Long orderId) {
+
+        // 1. 주문 존재 여부 조회
+        OrderInvoice orderInvoice = orderReader.getOrderInvoice(orderId);
+
+        // 2. 본인 주문인지 검증
+        verifyOrderOwnership(userId, orderInvoice);
+
+        // 3. 응답 객체로 변환
+        return orderInvoice.toResponseDto(orderInvoice);
 
     }
 


### PR DESCRIPTION
## 📌 작업 내용
- 등록된 주문의 상세 조회 기능 구현하였습니다.
- 본인의 주문 내역만 조회 가능하며, 취소된 주문의 경우에도 조회 가능합니다.

<br/>

## 🌱 반영 브랜치
- FM-21-feat/order-detail -> dev-sub
- close #41 

<br/>