### PR TITLE
[Feat] 주문 내역 목록 조회 기능 구현

### DIFF
--- a/fridaymarket_resource/build.gradle
+++ b/fridaymarket_resource/build.gradle
@@ -65,6 +65,13 @@ dependencies {
 
 	// ProtoBuf
 	implementation 'javax.annotation:javax.annotation-api:1.3.2'
+
+	// QueryDSL 설정
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	implementation "com.querydsl:querydsl-core:5.0.0"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.0"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
 }
 
 // gRPC 및 Protobuf 설정
@@ -85,22 +92,52 @@ protobuf {
 		}
 	}
 }
-// .proto 파일의 위치를 src/main/proto로 지정
+// 프로토콜 버퍼 파일 경로 설정
 sourceSets {
 	main {
 		proto {
 			srcDir 'src/main/proto'
 		}
+		java {
+			// 프로토콜 파일로부터 생성된 코드 경로를 포함
+			srcDirs += 'build/generated/source/proto/main/java'
+			srcDirs += 'build/generated/source/proto/main/grpc'
+		}
 	}
 }
 
+// 컴파일 태스크가 Protobuf 파일 생성을 포함하도록 의존성 설정
 compileJava {
-	dependsOn 'generateProto'
+	dependsOn generateProto
+}
+
+// Protobuf 관련 경로 정리
+clean {
+	delete 'build/generated'
 }
 
 tasks.processResources {
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
+
+// 경로설정
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+	main {
+		java {
+			srcDirs += querydslDir
+		}
+	}
+}
+
+tasks.withType(JavaCompile) {
+	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+//
+//clean {
+//	delete file(querydslDir)
+//}
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/controller/OrderController.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/controller/OrderController.java
@@ -2,6 +2,7 @@ package com.smile.fridaymarket_resource.domain.order.controller;
 
 import com.smile.fridaymarket_resource.auth.UserResponse;
 import com.smile.fridaymarket_resource.domain.order.dto.OrderCreateRequest;
+import com.smile.fridaymarket_resource.domain.order.dto.OrderPaging;
 import com.smile.fridaymarket_resource.domain.order.dto.OrderResponse;
 import com.smile.fridaymarket_resource.domain.order.service.OrderService;
 import com.smile.fridaymarket_resource.global.response.SuccessResponse;
@@ -10,6 +11,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+
+import org.springframework.data.domain.Pageable;
 
 @Slf4j
 @RestController
@@ -70,5 +73,11 @@ public class OrderController extends BaseController {
     public SuccessResponse<OrderResponse> getOrderInvoice(HttpServletRequest request, @PathVariable Long orderId) {
         UserResponse user = getUser(request);
         return SuccessResponse.successWithData(orderService.getOrderInvoice(user.userId(), orderId));
+    }
+
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    public SuccessResponse<OrderPaging> getOrderList(HttpServletRequest request, Pageable pageable) {
+        UserResponse user = getUser(request);
+        return SuccessResponse.successWithData(orderService.getOrderList(user.userId(), pageable));
     }
 }

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/dto/OrderList.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/dto/OrderList.java
@@ -1,0 +1,26 @@
+package com.smile.fridaymarket_resource.domain.order.dto;
+
+import com.smile.fridaymarket_resource.domain.order.entity.enums.OrderStatus;
+import com.smile.fridaymarket_resource.domain.order.entity.enums.OrderType;
+import com.smile.fridaymarket_resource.domain.product.entity.ProductName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class OrderList {
+
+    private Long orderId;
+    private OrderType orderType;
+    private ProductName productName;
+    private BigDecimal totalAmount;
+    private OrderStatus orderStatus;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+    private Boolean isDeleted;
+
+}

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/dto/OrderPaging.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/dto/OrderPaging.java
@@ -1,0 +1,27 @@
+package com.smile.fridaymarket_resource.domain.order.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class OrderPaging {
+
+    private int contentCnt;
+    private List<?> content = new ArrayList<>();
+    private int pageSize;
+    private int page;
+    private int totalPage;
+
+    public OrderPaging(Page<?> pageList) {
+        this.contentCnt = (int) pageList.getTotalElements();
+        this.content = pageList.getContent();
+        this.pageSize = pageList.getSize();
+        this.page = pageList.getPageable().getPageNumber();
+        this.totalPage = pageList.getTotalPages();
+    }
+}

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/repository/OrderInvoiceRepository.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/repository/OrderInvoiceRepository.java
@@ -1,7 +1,8 @@
 package com.smile.fridaymarket_resource.domain.order.repository;
 
 import com.smile.fridaymarket_resource.domain.order.entity.OrderInvoice;
+import com.smile.fridaymarket_resource.domain.order.repository.querydsl.OrderRepositoryQueryDsl;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderInvoiceRepository extends JpaRepository<OrderInvoice, Long> {
+public interface OrderInvoiceRepository extends JpaRepository<OrderInvoice, Long>, OrderRepositoryQueryDsl {
 }

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/repository/querydsl/OrderRepositoryQueryDsl.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/repository/querydsl/OrderRepositoryQueryDsl.java
@@ -1,0 +1,12 @@
+package com.smile.fridaymarket_resource.domain.order.repository.querydsl;
+
+import com.smile.fridaymarket_resource.domain.order.dto.OrderList;
+import org.springframework.data.domain.Page;
+
+import org.springframework.data.domain.Pageable;
+
+public interface OrderRepositoryQueryDsl {
+
+    Page<OrderList> getOrderList(String userId, Pageable pageable);
+
+}

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/repository/querydsl/OrderRepositoryQueryDslImpl.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/repository/querydsl/OrderRepositoryQueryDslImpl.java
@@ -1,0 +1,57 @@
+package com.smile.fridaymarket_resource.domain.order.repository.querydsl;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.smile.fridaymarket_resource.domain.order.dto.OrderList;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.smile.fridaymarket_resource.domain.order.entity.QOrderInvoice.orderInvoice;
+import static com.smile.fridaymarket_resource.domain.order.entity.QOrderProduct.orderProduct;
+
+public class OrderRepositoryQueryDslImpl implements OrderRepositoryQueryDsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    public OrderRepositoryQueryDslImpl(EntityManager em) {
+
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<OrderList> getOrderList(String userId, Pageable pageable) {
+
+        List<OrderList> orderLists = queryFactory
+                .select(Projections.constructor(OrderList.class,
+                        orderInvoice.id.as("orderId"),
+                        orderInvoice.orderType,
+                        orderProduct.product.productName,  // 첫 번째 상품만 가져오기
+                        orderInvoice.amount.as("totalAmount"),
+                        orderInvoice.orderStatus,
+                        orderInvoice.createdAt,
+                        orderInvoice.updatedAt,
+                        orderInvoice.deletedAt,
+                        orderInvoice.isDeleted
+                ))
+                .from(orderInvoice)
+                .join(orderInvoice.orderProducts, orderProduct)
+                .where(orderInvoice.userId.eq(UUID.fromString(userId))
+                        .and(orderInvoice.isDeleted.eq(false)))
+                .groupBy(orderInvoice.id)  // 각 주문서별로 첫 번째 상품만 가져오도록 그룹화
+                .orderBy(orderInvoice.createdAt.desc())  // 최신 주문 순으로 정렬
+                .fetch();
+
+        long total = queryFactory
+                .selectFrom(orderInvoice)
+                .where(orderInvoice.userId.eq(UUID.fromString(userId)))
+                .fetchCount();
+
+        return new PageImpl<>(orderLists, pageable, total);
+    }
+
+}

--- a/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderService.java
+++ b/fridaymarket_resource/src/main/java/com/smile/fridaymarket_resource/domain/order/service/OrderService.java
@@ -1,8 +1,11 @@
 package com.smile.fridaymarket_resource.domain.order.service;
 
 import com.smile.fridaymarket_resource.domain.order.dto.OrderCreateRequest;
+import com.smile.fridaymarket_resource.domain.order.dto.OrderPaging;
 import com.smile.fridaymarket_resource.domain.order.dto.OrderResponse;
 import org.springframework.stereotype.Service;
+
+import org.springframework.data.domain.Pageable;
 
 @Service
 public interface OrderService {
@@ -21,5 +24,7 @@ public interface OrderService {
     void cancelOrder(Long orderId);
 
     OrderResponse getOrderInvoice(String userId, Long orderId);
+
+    OrderPaging getOrderList(String userId, Pageable pageable);
 
 }


### PR DESCRIPTION
## 📌 작업 내용
- 사용자의 주문 내역 목록 조회 기능 구현하였습니다.
- 목록 조회 기능 구현 시 타입 안정성, 동적 쿼리 작성의 유연성, 가독성 및 성능 최적화를 고려해 QueryDsl 을 활용하였습니다.

<br/>

## 🌱 반영 브랜치
- FM-22-feat/order-list -> dev
- close #45 

<br/>

## 🔥 트러블 슈팅
### 1. OrderServiceImpl 클래스에 두 개의 빈이 발견된 문제
<details> <summary> 상세 내용 보기</summary> <br> <img width="650" alt="OrderServiceImpl 오류 발생" src="https://github.com/user-attachments/assets/3c1cc044-b34d-4374-b950-83d088e29b7c"> 

<br>

#### 원인 분석

- **OrderRepositoryQueryDsl 선언 문제**
  : OrderServiceImpl 클래스에서 OrderRepositoryQueryDsl을 직접 선언하면서 문제가 발생했습니다.

- **OrderInvoiceRepository 상속 구조 문제**
  : 이미 OrderInvoiceRepository가 OrderRepositoryQueryDsl을 상속받고 있는데, 중복 선언한 것이 빈 충돌을 일으켰습니다.

- **스프링 빈 충돌**
  : 생성자 주입 시 orderRepositoryQueryDslImpl과 orderInvoiceRepository 두 개의 빈이 충돌하면서 스프링이 어떤 빈을 사용할지 결정하지 못해 오류가 발생했습니다.

#### 해결 방법
- OrderServiceImpl 클래스에서 OrderInvoiceRepository를 선언하여 문제를 해결했습니다. 
- 불필요한 중복 선언을 없앰으로써 빈 충돌이 사라졌습니다.
</details> 

<br/>

### 2. 주문 내역 목록 조회 기능 구현 중 상품 이름 조회 오류

<details> <summary> 상세 내용 보기</summary> 

### 1) 서브쿼리 사용 시 발생한 오류 (Unsupported expression 문제)

**원인 분석**
 - Hibernate는 JPQL에서 서브쿼리로 orderProduct.product.productName과 같은 필드에 접근하는 것을 지원하지 않기 때문에 오류가 발생했습니다.

**해결 방법**
 - 서브쿼리를 사용하는 대신 JOIN을 명시적으로 적용하여 데이터를 가져왔습니다. 
 - 서브쿼리는 가능한 최소화하고 조인으로 성능과 가독성을 개선했습니다.

**해결 코드**
```
List<OrderList> orderLists = queryFactory
    .select(
        Projections.bean(
            OrderList.class,
            orderInvoice.id,
            orderInvoice.orderType,
            orderProduct.product.productName,
            orderInvoice.createdAt,
            orderInvoice.updatedAt,
            orderInvoice.deletedAt,
            orderInvoice.isDeleted
        )
    )
    .from(orderInvoice)
    .leftJoin(orderInvoice.orderProducts, orderProduct) // orderProducts와 연결
    .where(orderInvoice.userId.eq(UUID.fromString(userId)))
    .orderBy(orderInvoice.createdAt.desc())
    .offset(pageable.getOffset())
    .limit(pageable.getPageSize())
    .fetch();
```

<br>

### 2) Null 값 반환 문제

  **원인 분석**
  - Projections.bean 방식을 사용할 때, OrderList 클래스가 기본 생성자와 setter 메서드를 가지고 있어야만 필드 값들이 정상적으로 매핑됩니다. 
  - 하지만,OrderList에 기본 생성자 및 setter 메서드가 없었기에 null 값이 반환되었습니다.

   **해결 방법**
  - Projections.bean() 대신 ```Projections.constructor()```를 사용해 값을 호출했습니다. 
  - 이 방식은 매핑 클래스에 생성자만 있으면 값이 정상적으로 전달되므로, 기본 생성자나 setter가 필요하지 않습니다.

  **해결 코드**
```
List<OrderList> orderLists = queryFactory
    .select(
        Projections.constructor(
            OrderList.class,
            orderInvoice.id,
            orderInvoice.orderType,
            orderProduct.product.productName,
            orderInvoice.createdAt,
            orderInvoice.updatedAt,
            orderInvoice.deletedAt,
            orderInvoice.isDeleted
        )
    )
    .from(orderInvoice)
    .leftJoin(orderInvoice.orderProducts, orderProduct)
    .where(orderInvoice.userId.eq(UUID.fromString(userId)))
    .orderBy(orderInvoice.createdAt.desc())
    .offset(pageable.getOffset())
    .limit(pageable.getPageSize())
    .fetch();
```
![image](https://github.com/user-attachments/assets/37d84f82-e861-4454-a5e4-0b6dea6586a6)

</details>